### PR TITLE
 Feat:. Implementação da lógica e dashboard dos indicadores de desempenho

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel
 
 from .database import engine
-from .routers import corridas, rankings, telemetria
+from .routers import corridas, rankings
 
 # Importar modelos para que o SQLModel.metadata os registre
 from . import models  # noqa: F401
@@ -39,7 +39,6 @@ app.add_middleware(
 # Registrar routers
 app.include_router(corridas.router)
 app.include_router(rankings.router)
-app.include_router(telemetria.router)
 
 
 @app.get("/", tags=["health"])

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel
 
 from .database import engine
-from .routers import corridas, rankings
+from .routers import corridas, rankings, telemetria
 
 # Importar modelos para que o SQLModel.metadata os registre
 from . import models  # noqa: F401
@@ -39,6 +39,7 @@ app.add_middleware(
 # Registrar routers
 app.include_router(corridas.router)
 app.include_router(rankings.router)
+app.include_router(telemetria.router)
 
 
 @app.get("/", tags=["health"])

--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -11,7 +11,7 @@ from ..services.websocket_manager import manager
 from ..models.corrida import Corrida
 from ..models.labirinto import Labirinto
 from ..models.enums import StatusCorrida, TipoLabirinto
-
+from ..schemas.telemetria import PacoteInicial, PacoteMovimentacao, PacoteFinal
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/telemetria", tags=["telemetria"])
@@ -40,14 +40,17 @@ async def websocket_telemetria(websocket: WebSocket):
 
 @router.post("/pacote", status_code=201)
 async def receber_pacote_telemetria(
-    pacote: dict,
+    payload: PacoteInicial | PacoteMovimentacao | PacoteFinal,
     session: Session = Depends(get_session)
 ):
     """
     Endpoint HTTP para o Micromouse enviar pacotes de telemetria.
     Recebe o pacote, atualiza o estado em memória e notifica o Dashboard.
     """
+    pacote = payload.model_dump()
     tipo = identificar_tipo_pacote(pacote)
+    # print(f"Tipo de pacote: {tipo}")
+    # print(f"Payload: {pacote}")
     if tipo == TipoPacote.INVALIDO:
         raise HTTPException(
             status_code=400, detail="Pacote inválido ou não reconhecido")

--- a/src/backend/app/schemas/telemetria.py
+++ b/src/backend/app/schemas/telemetria.py
@@ -49,7 +49,7 @@ class PacoteInicial(BaseModel):
 
     id_corrida: int
     timestamp_ms: int = Field(ge=0)
-    dimensao: str
+    dimensao: int | str
     tentativa: int
     bateria: float = Field(ge=0, le=100)
 

--- a/src/backend/app/services/websocket_manager.py
+++ b/src/backend/app/services/websocket_manager.py
@@ -14,12 +14,21 @@ class ConnectionManager:
             self.active_connections.remove(websocket)
 
     async def send_json_to_client(self, message: dict, client: WebSocket):
-        for connection in self.active_connections:
-            if connection == client:
-                await connection.send_json(message)
+        if client in self.active_connections:
+            try:
+                await client.send_json(message)
+            except Exception:
+                self.disconnect(client)
 
     async def send_json_to_all_clients(self, message: dict):
+        dead_connections = []
         for connection in self.active_connections:
-            await connection.send_json(message)
+            try:
+                await connection.send_json(message)
+            except Exception:
+                dead_connections.append(connection)
+        
+        for dead in dead_connections:
+            self.disconnect(dead)
 
 manager = ConnectionManager()

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,5 +1,7 @@
+import { TelemetriaPage } from './pages/TelemetriaPage';
+
 function App() {
-  return <h1 className="text-3xl font-bold underline">Hello world!</h1>;
+  return <TelemetriaPage />;
 }
 
 export default App;

--- a/src/frontend/src/components/DashboardIndicadores.tsx
+++ b/src/frontend/src/components/DashboardIndicadores.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useTelemetria } from "../hooks/useTelemetria";
+
+type StatusCorrida = "aguardando" | "em_andamento" | "concluida" | "abortada";
+
+type IndicadoresTelemetria = {
+  bateria_atual?: number | null;
+  velocidade_media?: number | null;
+  tempo_decorrido_ms?: number | null;
+  tempo_final_ms?: number | null;
+  status_corrida?: StatusCorrida | string | null;
+  ultimo_timestamp_ms?: number | null;
+};
+
+const LIMITE_BATERIA_CRITICA = 15;
+const LIMITE_SEM_TELEMETRIA_MS = 3000;
+
+const formatarTempo = (ms?: number | null): string => {
+  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
+    return "00:00.000";
+  }
+
+  const minutos = Math.floor(ms / 60000);
+  const segundos = Math.floor((ms % 60000) / 1000);
+  const milissegundos = Math.floor(ms % 1000);
+
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(
+    2,
+    "0",
+  )}.${String(milissegundos).padStart(3, "0")}`;
+};
+
+const normalizarStatus = (status?: string | null): StatusCorrida => {
+  const valor = status?.toLowerCase();
+
+  if (valor === "em_andamento" || valor === "concluida" || valor === "abortada") {
+    return valor;
+  }
+
+  return "aguardando";
+};
+
+const rotuloStatus: Record<StatusCorrida, string> = {
+  aguardando: "Aguardando",
+  em_andamento: "Em andamento",
+  concluida: "Concluída",
+  abortada: "Abortada",
+};
+
+const obterNumeroValido = (valor?: number | null): number | null => {
+  if (valor === null || valor === undefined || Number.isNaN(valor)) {
+    return null;
+  }
+
+  return valor;
+};
+
+type CardIndicadorProps = {
+  titulo: string;
+  valor: string;
+  descricao?: string;
+  estado?: "normal" | "critico" | "sucesso" | "vazio";
+};
+
+const CardIndicador: React.FC<CardIndicadorProps> = ({
+  titulo,
+  valor,
+  descricao,
+  estado = "normal",
+}) => {
+  const estilos = {
+    normal: "border-neutral-200 bg-white text-neutral-900",
+    critico: "border-red-300 bg-red-50 text-red-950",
+    sucesso: "border-green-300 bg-green-50 text-green-950",
+    vazio: "border-neutral-200 bg-neutral-50 text-neutral-400",
+  }[estado];
+
+  return (
+    <section className={`rounded-xl border p-5 transition-colors ${estilos}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+        {titulo}
+      </p>
+      <p className="mt-3 text-3xl font-semibold tracking-tight">{valor}</p>
+      {descricao && <p className="mt-2 text-xs text-current opacity-75">{descricao}</p>}
+    </section>
+  );
+};
+
+export const DashboardIndicadores: React.FC = () => {
+  const { indicadores, conectado } = useTelemetria() as {
+    indicadores?: IndicadoresTelemetria | null;
+    conectado: boolean;
+  };
+
+  const [alertaSemSinal, setAlertaSemSinal] = useState(false);
+
+  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
+  const corridaAguardando = !indicadores || statusCorrida === "aguardando";
+  const corridaConcluida = statusCorrida === "concluida";
+  const corridaAbortada = statusCorrida === "abortada";
+
+  const bateriaAtual = obterNumeroValido(indicadores?.bateria_atual);
+  const velocidadeMedia = obterNumeroValido(indicadores?.velocidade_media);
+  const tempoDecorridoMs = obterNumeroValido(indicadores?.tempo_decorrido_ms) ?? 0;
+  const tempoFinalMs = obterNumeroValido(indicadores?.tempo_final_ms);
+  const ultimoTimestampMs = obterNumeroValido(indicadores?.ultimo_timestamp_ms);
+
+  const bateriaCritica = bateriaAtual !== null && bateriaAtual < LIMITE_BATERIA_CRITICA;
+
+  const tempoExibido = useMemo(() => {
+    if (corridaConcluida && tempoFinalMs !== null) {
+      return tempoFinalMs;
+    }
+
+    return tempoDecorridoMs;
+  }, [corridaConcluida, tempoDecorridoMs, tempoFinalMs]);
+
+  useEffect(() => {
+    if (!indicadores || statusCorrida !== "em_andamento") {
+      setAlertaSemSinal(false);
+      return;
+    }
+
+    setAlertaSemSinal(false);
+
+    const timer = window.setTimeout(() => {
+      setAlertaSemSinal(true);
+    }, LIMITE_SEM_TELEMETRIA_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [indicadores, statusCorrida, ultimoTimestampMs]);
+
+  return (
+    <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+      <header className="mb-6 flex flex-col gap-3 border-b border-neutral-100 pb-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Telemetria
+          </p>
+          <h2 className="text-2xl font-semibold text-neutral-950">
+            Indicadores de Desempenho
+          </h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            Métricas em tempo real da corrida do Micromouse.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span
+            className={`rounded-full px-3 py-1 font-medium ${
+              conectado
+                ? "bg-green-100 text-green-700"
+                : "bg-red-100 text-red-700"
+            }`}
+          >
+            WebSocket: {conectado ? "Conectado" : "Desconectado"}
+          </span>
+          <span className="rounded-full bg-neutral-100 px-3 py-1 font-medium text-neutral-700">
+            Corrida: {rotuloStatus[statusCorrida]}
+          </span>
+        </div>
+      </header>
+
+      <div className="mb-5 space-y-3">
+        {bateriaCritica && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
+            ⚠️ Bateria crítica: nível abaixo de {LIMITE_BATERIA_CRITICA}%.
+          </div>
+        )}
+
+        {alertaSemSinal && (
+          <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm font-medium text-yellow-800">
+            ⚠️ Ausência de telemetria recente: sem novos pacotes há mais de 3 segundos.
+          </div>
+        )}
+      </div>
+
+      <main className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <CardIndicador
+          titulo="Bateria"
+          valor={corridaAguardando || bateriaAtual === null ? "--%" : `${bateriaAtual.toFixed(1)}%`}
+          descricao={
+            bateriaCritica
+              ? "Bateria crítica"
+              : corridaAguardando
+                ? "Aguardando telemetria"
+                : "Última bateria conhecida"
+          }
+          estado={corridaAguardando ? "vazio" : bateriaCritica ? "critico" : "normal"}
+        />
+
+        <CardIndicador
+          titulo="Velocidade média"
+          valor={
+            corridaAguardando || velocidadeMedia === null || velocidadeMedia < 0
+              ? "-- cm/s"
+              : `${velocidadeMedia.toFixed(2)} cm/s`
+          }
+          descricao={corridaAguardando ? "Aguardando deslocamento" : "Calculada pela telemetria"}
+          estado={corridaAguardando ? "vazio" : "normal"}
+        />
+
+        <CardIndicador
+          titulo={corridaConcluida || corridaAbortada ? "Tempo final" : "Tempo decorrido"}
+          valor={corridaAguardando ? "00:00.000" : formatarTempo(tempoExibido)}
+          descricao={
+            corridaConcluida
+              ? "Tempo fixado após conclusão"
+              : corridaAbortada
+                ? "Tempo fixado após encerramento"
+                : corridaAguardando
+                  ? "Aguardando largada"
+                  : "Atualizado durante a corrida"
+          }
+          estado={
+            corridaAguardando
+              ? "vazio"
+              : corridaConcluida
+                ? "sucesso"
+                : corridaAbortada
+                  ? "critico"
+                  : "normal"
+          }
+        />
+      </main>
+    </div>
+  );
+};

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -69,9 +69,10 @@ export function useTelemetria(): UseTelemetriaReturn {
 
     ws.onmessage = (event) => {
       try {
-        const data = JSON.parse(event.data) as IndicadoresDesempenho;
-        // console.log("[useTelemetria] Dados recebidos:", data);
-        setIndicadores(data);
+        const parsed = JSON.parse(event.data);
+        if (parsed.type === "ATUALIZACAO_TELEMETRIA" && parsed.data) {
+          setIndicadores(parsed.data as IndicadoresDesempenho);
+        }
       } catch {
         console.error("[useTelemetria] Erro ao parsear mensagem:", event.data);
       }

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -1,0 +1,118 @@
+/**
+ * Hook React para conexão WebSocket de telemetria em tempo real.
+ *
+ * Uso:
+ * ```tsx
+ * const { indicadores, enviarPacote, conectado, erro } = useTelemetria();
+ * ```
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { IndicadoresDesempenho, PacoteTelemetria } from "../types/telemetria";
+import { WS_TELEMETRIA_URL } from "../services/telemetria";
+
+/** Estado inicial dos indicadores (espelha criar_estado_inicial do backend). */
+const ESTADO_INICIAL: IndicadoresDesempenho = {
+  id_corrida_banco: null,
+  sessao_hardware_id: null,
+  bateria_atual: null,
+  velocidade_media: null,
+  tempo_decorrido_ms: 0,
+  tempo_final_ms: null,
+  status_corrida: "aguardando",
+  sucesso: null,
+  ultimo_timestamp_ms: null,
+  alerta_bateria_critica: false,
+  alerta_dado_invalido: false,
+};
+
+/** Intervalo entre tentativas de reconexão (ms). */
+const RECONNECT_INTERVAL_MS = 3000;
+
+export interface UseTelemetriaReturn {
+  /** Estado atual dos indicadores de desempenho. */
+  indicadores: IndicadoresDesempenho;
+  /** Envia um pacote de telemetria via WebSocket. */
+  enviarPacote: (pacote: PacoteTelemetria) => void;
+  /** Indica se o WebSocket está conectado. */
+  conectado: boolean;
+  /** Última mensagem de erro, se houver. */
+  erro: string | null;
+}
+
+export function useTelemetria(): UseTelemetriaReturn {
+  const [indicadores, setIndicadores] =
+    useState<IndicadoresDesempenho>(ESTADO_INICIAL);
+  const [conectado, setConectado] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const conectar = useCallback(() => {
+    // Evitar conexões duplicadas
+    if (
+      wsRef.current &&
+      (wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+
+    const ws = new WebSocket(WS_TELEMETRIA_URL);
+
+    ws.onopen = () => {
+      setConectado(true);
+      setErro(null);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as IndicadoresDesempenho;
+        // console.log("[useTelemetria] Dados recebidos:", data);
+        setIndicadores(data);
+      } catch {
+        console.error("[useTelemetria] Erro ao parsear mensagem:", event.data);
+      }
+    };
+
+    ws.onerror = () => {
+      setErro("Erro na conexão WebSocket.");
+    };
+
+    ws.onclose = () => {
+      setConectado(false);
+      wsRef.current = null;
+
+      // Reconexão automática
+      reconnectTimerRef.current = setTimeout(conectar, RECONNECT_INTERVAL_MS);
+    };
+
+    wsRef.current = ws;
+  }, []);
+
+  useEffect(() => {
+    conectar();
+
+    return () => {
+      // Cleanup ao desmontar
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [conectar]);
+
+  const enviarPacote = useCallback((pacote: PacoteTelemetria) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(pacote));
+    } else {
+      console.warn("[useTelemetria] WebSocket não conectado, pacote descartado.");
+    }
+  }, []);
+
+  return { indicadores, enviarPacote, conectado, erro };
+}

--- a/src/frontend/src/pages/TelemetriaPage.tsx
+++ b/src/frontend/src/pages/TelemetriaPage.tsx
@@ -1,0 +1,130 @@
+import { DashboardIndicadores } from '../components/DashboardIndicadores';
+
+export function TelemetriaPage() {
+  return (
+    <div className="min-h-screen bg-[#FAFAFA] text-zinc-900">
+      <div className="flex min-h-screen">
+        {/* Sidebar */}
+        <aside className="hidden w-64 border-r border-zinc-200 bg-white lg:flex lg:flex-col">
+          <div className="flex h-16 items-center gap-3 border-b border-zinc-200 px-5">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-violet-600 text-white">
+              🤖
+            </div>
+
+            <div>
+              <h1 className="text-sm font-semibold text-zinc-900">
+                Micromouse
+              </h1>
+              <p className="text-xs text-zinc-500">Control Center</p>
+            </div>
+          </div>
+
+          <nav className="flex-1 space-y-1 px-3 py-6">
+            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
+              <span>▦</span>
+              Visão Geral
+            </button>
+
+            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
+              <span>⌗</span>
+              Labirinto
+            </button>
+
+            <button className="flex w-full items-center gap-3 rounded-lg bg-zinc-950 px-3 py-2 text-sm font-medium text-white">
+              <span>⌁</span>
+              Telemetria
+            </button>
+
+            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
+              <span>▣</span>
+              Estados
+            </button>
+
+            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
+              <span>↺</span>
+              Histórico
+            </button>
+
+            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
+              <span>⚙</span>
+              Configuração
+            </button>
+          </nav>
+
+          <div className="m-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+            <p className="text-xs font-medium uppercase text-zinc-500">
+              Firmware
+            </p>
+            <div className="mt-2 flex items-center justify-between">
+              <span className="text-xs text-zinc-500">Sincronizado</span>
+              <span className="rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-700">
+                v2.4.1
+              </span>
+            </div>
+          </div>
+        </aside>
+
+        {/* Área principal */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Topbar */}
+          <header className="flex h-16 items-center justify-between border-b border-zinc-200 bg-white px-4 lg:px-8">
+            <div>
+              <p className="text-xs text-zinc-500">Sessão #2026-05-02-014</p>
+              <h2 className="text-sm font-medium text-zinc-900">
+                Painel de Monitoramento — Robô MM-07
+              </h2>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="hidden md:block">
+                <input
+                  type="text"
+                  placeholder="Buscar evento, sessão..."
+                  className="h-9 w-64 rounded-lg border border-zinc-200 bg-white px-3 text-sm outline-none transition placeholder:text-zinc-400 focus:border-violet-500"
+                />
+              </div>
+
+              <div className="flex h-9 items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 text-sm font-medium text-zinc-700">
+                <span className="h-2 w-2 rounded-full bg-green-500" />
+                Online
+              </div>
+
+              <button
+                type="button"
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-white text-sm text-zinc-600"
+              >
+                🔔
+              </button>
+
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-950 text-xs font-semibold text-white">
+                AL
+              </div>
+            </div>
+          </header>
+
+          {/* Conteúdo */}
+          <main className="flex-1 px-4 py-8 lg:px-10">
+            <section className="mx-auto w-full max-w-6xl">
+              <div className="mb-6">
+                <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Telemetria
+                </p>
+
+                <h1 className="mt-1 text-2xl font-semibold text-zinc-950">
+                  Métricas em tempo real do robô MM-07
+                </h1>
+
+                <p className="mt-2 max-w-2xl text-sm text-zinc-500">
+                  Acompanhe os indicadores exigidos para avaliação da corrida:
+                  bateria, velocidade média e tempo de execução.
+                </p>
+              </div>
+
+              <DashboardIndicadores />
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/services/telemetria.ts
+++ b/src/frontend/src/services/telemetria.ts
@@ -1,0 +1,15 @@
+/**
+ * Constantes e funções utilitárias para telemetria.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuração do WebSocket
+// ---------------------------------------------------------------------------
+
+/**
+ * URL base do WebSocket de telemetria.
+ * Em desenvolvimento usa localhost; em produção, ajustar conforme deploy.
+ */
+export const WS_TELEMETRIA_URL =
+  import.meta.env.VITE_WS_TELEMETRIA_URL ?? "ws://localhost:8000/api/telemetria/ws";
+

--- a/src/frontend/src/types/telemetria.ts
+++ b/src/frontend/src/types/telemetria.ts
@@ -1,0 +1,71 @@
+/**
+ * Tipos TypeScript para pacotes de telemetria e indicadores de desempenho.
+ *
+ * Espelha os schemas Pydantic do backend para garantir tipagem consistente.
+ */
+
+// ---------------------------------------------------------------------------
+// Status da corrida
+// ---------------------------------------------------------------------------
+
+export type StatusCorridaTelemetria =
+  | "aguardando"
+  | "em_andamento"
+  | "concluida"
+  | "falha";
+
+// ---------------------------------------------------------------------------
+// Pacotes de telemetria
+// ---------------------------------------------------------------------------
+
+/** Pacote de início/configuração da corrida. */
+export interface PacoteInicial {
+  id_corrida: number;
+  timestamp_ms: number;
+  dimensao: string;
+  tentativa: number;
+  bateria: number;
+}
+
+/** Pacote de movimentação durante a corrida. */
+export interface PacoteMovimentacao {
+  id_corrida: number;
+  timestamp_ms: number;
+  x: number;
+  y: number;
+  w: number;
+  bateria?: number;
+}
+
+/** Pacote consolidado ao fim da corrida. */
+export interface PacoteFinal {
+  id_corrida: number;
+  timestamp_ms: number;
+  sucesso: boolean;
+  v_med: number;
+  bateria: number;
+}
+
+/** Union type de todos os pacotes de telemetria. */
+export type PacoteTelemetria = PacoteInicial | PacoteMovimentacao | PacoteFinal;
+
+// ---------------------------------------------------------------------------
+// Estado dos indicadores
+// ---------------------------------------------------------------------------
+
+/** Estado consolidado dos indicadores de desempenho do dashboard. */
+export interface IndicadoresDesempenho {
+  id_corrida_banco: number | null;
+  sessao_hardware_id: number | null;
+  bateria_inicial: number | null;
+  bateria_atual: number | null;
+  bateria_final: number | null;
+  velocidade_media: number | null;
+  tempo_decorrido_ms: number;
+  tempo_final_ms: number | null;
+  status_corrida: StatusCorridaTelemetria;
+  sucesso: boolean | null;
+  ultimo_timestamp_ms: number | null;
+  alerta_bateria_critica: boolean;
+  alerta_dado_invalido: boolean;
+}


### PR DESCRIPTION

## Descrição

Este PR implementa de forma integrada a camada de processamento de pacotes via WebSocket e a interface visual em tempo real para os indicadores de desempenho do Micromouse. O sistema consome as atualizações estruturadas de telemetria diretamente do backend em FastAPI e renderiza os dados dinamicamente no frontend em React, tratando estados iniciais, thresholds críticos e encerramento de sessões.

## Issues Relacionadas

* Fixes: **Task(Telemetria): Implementar lógica dos indicadores de desempenho**
* Fixes: **Task(Dashboard): Implementar exibição dos indicadores no dashboard**

---

## Alterações Realizadas

### Lógica e Telemetria (Camada de Aplicação/Hook)
* **Mapeamento e Parsing:** Integração com os contratos reativos do backend, mapeando propriedades estruturadas como `id_corrida_banco`, `bateria_atual`, `velocidade_media`, `tempo_decorrido_ms`, `tempo_final_ms` e `status_corrida`.
* **Gerenciamento de Fluxo:** Implementação do hook customizado `useTelemetria.ts` para abrir e gerenciar o ciclo de vida da conexão via WebSocket (`WSS`), contendo mecanismos automáticos de reconexão a cada 3000ms.
* **Validação:** Tratamento de pacotes recebidos na stream para garantir que atualizações na interface ocorram exclusivamente com base em payloads estruturados do tipo `ATUALIZACAO_TELEMETRIA`.

### Interface Visual e Dashboard (Camada de Apresentação)
* **Desenvolvimento de Componentes:** Criação do módulo modular `DashboardIndicadores.tsx`, adicionando três cards principais legíveis e focados nos indicadores obrigatórios:
  * **Bateria (%):** Mostra o nível atual do robô ou indicador `--%` no estado inicial.
  * **Velocidade Média (cm/s):** Exibe o cálculo acumulado de deslocamento com precisão de duas casas decimais.
  * **Tempo de Corrida:** Cronômetro dinâmico formatado estritamente no padrão `MM:SS.mmm`.
* **Fixação de Tempo Final:** Implementada lógica visual para detectar o estado de transição para `status_corrida === "concluida"`. O cronômetro interrompe a contagem em tempo real e congela o layout exibindo o valor fixo vindo de `tempo_final_ms`.
* **Motor de Alertas Visuais:**
  * **Threshold de Bateria:** Ativação automática de estilos de perigo (fundo vermelho sutil e texto em destaque) e aviso de `Bateria Crítica` sempre que a carga cai abaixo de 15%.
  * **Watchdog de Sinal (Timeout):** Implementação de um temporizador de 3 segundos disparado no front-end. Caso o robô esteja em andamento e pare de enviar dados por esse período, a tela renderiza um banner superior de atenção sinalizando ausência de telemetria recente.

### Refatoração e Qualidade de Código
* **Isolamento de Estilos:** Extração das lógicas condicionais de strings do Tailwind CSS de dentro do escopo do JSX (`return`), organizando-as em variáveis declarativas no início do componente.
* **Ajustes de Ambiente:** Homologação do ambiente do frontend para Node.js v20 (via NVM) e reconfiguração limpa dos bindings nativos do compilador do Vite, mitigando erros de runtime no ambiente Linux.

---

## Como Testar Manualmente

1. Certifique-se de que o backend esteja ativo enviando a stream de eventos ou utilize dados simulados direto pelo canal do WebSocket.
2. No diretório do frontend, garanta o uso do Node 20 com `nvm use 20` e levante o servidor via `npm run dev`.
3. Abra a aplicação em `http://localhost:5173/`.
4. **Cenário 1 (Aguardando):** Valide se os componentes iniciam em modo opaco, cinza e com os placeholders (`--%`, `-- cm/s`, `00:00.000`) ativos.
5. **Cenário 2 (Em andamento):** Simule o início da corrida. O cronômetro deve começar a rodar dinamicamente e os valores de velocidade devem ser atualizados.
6. **Cenário 3 (Bateria < 15%):** Reduza o valor da bateria para menos de 15% no payload enviado e verifique se o card correspondente assume coloração vermelha de perigo imediatamente.
7. **Cenário 4 (Inatividade):** Interrompa o envio de pacotes por mais de 3 segundos com a corrida ativa e cheque se o banner amarelo de ausência de sinal é exibido no topo.
8. **Cenário 5 (Conclusão):** Altere o status para `"concluida"`. O cronômetro deve travar instantaneamente no tempo final estipulado e assumir a cor verde de sucesso.

---

## Co-autores
```text
Co-authored-by: Euller <euller2005@gmail.com>