### PR TITLE
94 us 10 validação da telemetria recebida

### DIFF
--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -5,14 +5,19 @@ from sqlmodel import Session
 import logging
 
 from ..database import get_session
-from ..services.telemetria import atualizar_indicadores, criar_estado_inicial, identificar_tipo_pacote
+from ..services.telemetria import (
+    atualizar_indicadores,
+    criar_estado_inicial,
+    identificar_tipo_pacote,
+    validar_pacote,
+)
 from ..schemas.telemetria import IndicadoresDesempenho, TipoPacote
 from ..services.websocket_manager import manager
 from ..models.corrida import Corrida
 from ..models.evento import Evento
 from ..models.labirinto import Labirinto
 from ..models.enums import StatusCorrida, TipoLabirinto
-from ..schemas.telemetria import PacoteInicial, PacoteMovimentacao, PacoteFinal
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/telemetria", tags=["telemetria"])
@@ -41,33 +46,49 @@ async def websocket_telemetria(websocket: WebSocket):
 
 @router.post("/pacote", status_code=201)
 async def receber_pacote_telemetria(
-    payload: PacoteInicial | PacoteMovimentacao | PacoteFinal,
+    payload: Dict[str, Any],
     session: Session = Depends(get_session)
 ):
     """
     Endpoint HTTP para o Micromouse enviar pacotes de telemetria.
     Recebe o pacote, atualiza o estado em memória e notifica o Dashboard.
     """
-    pacote = payload.model_dump()
+    pacote = payload
     tipo = identificar_tipo_pacote(pacote)
-    # print(f"Tipo de pacote: {tipo}")
-    # print(f"Payload: {pacote}")
-    if tipo == TipoPacote.INVALIDO:
-        raise HTTPException(
-            status_code=400, detail="Pacote inválido ou não reconhecido")
 
+    # 1. Recupera o ID da corrida para verificar o estado em memória
     sessao_hardware_id = pacote.get("id_corrida")
-    if sessao_hardware_id is None:
-        raise HTTPException(
-            status_code=400, detail="id_corrida ausente no pacote")
+    
+    # 2. Obtém o último timestamp se a sessão já existir (para validar regressão)
+    ultimo_ts = None
+    if isinstance(sessao_hardware_id, int) and sessao_hardware_id in estados_ativos:
+        ultimo_ts = estados_ativos[sessao_hardware_id].ultimo_timestamp_ms
 
-    # Recupera ou inicializa o estado em memória
+    # 3. BARREIRA DE VALIDAÇÃO RIGOROSA
+    # Executa as regras de negócio antes de QUALQUER processamento ou persistência
+    resultado = validar_pacote(pacote, tipo, ultimo_ts)
+    if not resultado.valido:
+        logger.warning(
+            "Pacote REJEITADO por falha na validação (ID: %s): %s",
+            sessao_hardware_id,
+            resultado.erros,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "mensagem": "Pacote descartado por falha na validação",
+                "erros": resultado.erros,
+            },
+        )
+
+    # 4. Inicializa estado se for o primeiro pacote válido desta sessão
+    # (Garantido pelo validar_pacote que sessao_hardware_id é int aqui)
     if sessao_hardware_id not in estados_ativos:
         estados_ativos[sessao_hardware_id] = criar_estado_inicial()
 
     estado_atual = estados_ativos[sessao_hardware_id]
 
-    # Processa os indicadores puros
+    # 5. Processa os indicadores puros (Cálculos de velocidade, etc)
     novo_estado = atualizar_indicadores(estado_atual, pacote)
 
     commit_realizado = False
@@ -82,10 +103,7 @@ async def receber_pacote_telemetria(
             tipo_lab = TipoLabirinto.DEZESSEIS
         elif int(dimensao) == 4:
             tipo_lab = TipoLabirinto.QUATRO
-        else:
-            raise HTTPException(
-                status_code=400, detail="Dimensão inválida do labirinto")
-
+        
         labirinto = Labirinto(tipo_labirinto=tipo_lab)
         session.add(labirinto)
         session.flush()
@@ -108,6 +126,7 @@ async def receber_pacote_telemetria(
         session.commit()
         session.refresh(corrida)
         commit_realizado = True
+
     # Se for pacote final, atualizar o banco de dados
     if tipo == TipoPacote.FINAL and novo_estado.id_corrida_banco is not None:
         corrida = session.get(Corrida, novo_estado.id_corrida_banco)

--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -43,6 +43,19 @@ async def websocket_telemetria(websocket: WebSocket):
         }
     }
     await manager.send_json_to_client(handshake, websocket)
+    
+    # Enviar status atual de todas as corridas ativas para o novo cliente
+    for sid in estados_ativos:
+        status = connection_monitor.get_status(sid) or "online"
+        await manager.send_json_to_client({
+            "type": "CONNECTION_STATUS",
+            "data": {
+                "id_corrida": sid,
+                "status": status,
+                "message": "Status recuperado ao conectar"
+            }
+        }, websocket)
+
     try:
         while True:
             await websocket.receive_json()
@@ -76,7 +89,15 @@ async def receber_pacote_telemetria(
     # 3. BARREIRA DE VALIDAÇÃO RIGOROSA
     resultado = validar_pacote(pacote, tipo, ultimo_ts)
     if not resultado.valido:
-        logger.warning("Pacote REJEITADO por falha na validação: %s", resultado.erros)
+        erros_str = ", ".join(resultado.erros)
+        logger.warning("Pacote REJEITADO por falha na validação: %s", erros_str)
+        
+        # Notificar o dashboard sobre o erro de validação
+        await manager.send_json_to_all_clients({
+            "type": "ERROR",
+            "message": f"Dados inválidos do robô: {erros_str}"
+        })
+
         raise HTTPException(
             status_code=422,
             detail={"mensagem": "Pacote descartado", "erros": resultado.erros},
@@ -86,6 +107,18 @@ async def receber_pacote_telemetria(
     if tipo == TipoPacote.INICIAL and sessao_hardware_id not in estados_ativos:
         await _abortar_corridas_ativas(session, sessao_hardware_id)
 
+    elif tipo == TipoPacote.INICIAL and sessao_hardware_id in estados_ativos:
+        # Recebimento de pacote INICIAL com um `sessao_hardware_id` já em uso.
+        # Enviar notificação de erro ao dashboard e retornar uma exceção
+        logger.error("Pacote INICIAL rejeitado: id de sessão repetido %s", sessao_hardware_id)
+        await manager.send_json_to_all_clients({
+            "type": "ERROR",
+            "message": f"ID de sessão repetido recebido: {sessao_hardware_id}. Pacote INICIAL rejeitado."
+        })
+        raise HTTPException(
+            status_code=404,
+            detail={"mensagem": "ID de sessão repetido", "id_corrida": sessao_hardware_id},
+        )
     # 5. Inicializa ou recupera estado
     if sessao_hardware_id not in estados_ativos:
         estados_ativos[sessao_hardware_id] = criar_estado_inicial()

--- a/src/backend/app/services/telemetria.py
+++ b/src/backend/app/services/telemetria.py
@@ -111,16 +111,19 @@ def validar_pacote(
         return ResultadoValidacao(valido=False, erros=erros)
 
     # --- Campos obrigatórios gerais ---
-    if "id_corrida" not in packet:
+    id_corrida = packet.get("id_corrida")
+    if id_corrida is None:
         erros.append("Campo 'id_corrida' ausente.")
+    elif not isinstance(id_corrida, int):
+        erros.append(f"Campo 'id_corrida' deve ser um número inteiro (recebido: {id_corrida}).")
 
     ts = packet.get("timestamp_ms")
     if ts is None:
         erros.append("Campo 'timestamp_ms' ausente.")
-    elif not isinstance(ts, (int, float)):
-        erros.append("Campo 'timestamp_ms' deve ser numérico.")
+    elif not isinstance(ts, int):
+        erros.append(f"Campo 'timestamp_ms' deve ser um número inteiro (recebido: {ts}).")
     elif ts < 0:
-        erros.append("Campo 'timestamp_ms' não pode ser negativo.")
+        erros.append(f"Campo 'timestamp_ms' não pode ser negativo (recebido: {ts}).")
 
     # --- Validação por tipo ---
     if tipo == TipoPacote.INICIAL:
@@ -134,18 +137,25 @@ def validar_pacote(
 
 
 def _validar_pacote_inicial(packet: dict, erros: list[str]) -> None:
-    if "dimensao" not in packet:
+    dimensao = packet.get("dimensao")
+    if dimensao is None:
         erros.append("Campo 'dimensao' ausente no pacote inicial.")
-    if "tentativa" not in packet:
+    elif dimensao not in (4, 8, 16):
+        erros.append(f"Dimensão inválida: deve ser 4, 8 ou 16 (recebido: {dimensao}).")
+
+    tentativa = packet.get("tentativa")
+    if tentativa is None:
         erros.append("Campo 'tentativa' ausente no pacote inicial.")
+    elif tentativa not in (1, 2, 3):
+        erros.append(f"Tentativa fora do limite: deve ser 1, 2 ou 3 (recebido: {tentativa}).")
 
     bateria = packet.get("bateria")
     if bateria is None:
         erros.append("Campo 'bateria' ausente no pacote inicial.")
     elif not isinstance(bateria, (int, float)):
-        erros.append("Campo 'bateria' deve ser numérico.")
+        erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
     elif not (0 <= bateria <= 100):
-        erros.append("Campo 'bateria' deve estar entre 0 e 100.")
+        erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
 
 def _validar_pacote_movimentacao(
@@ -158,12 +168,12 @@ def _validar_pacote_movimentacao(
         if valor is None:
             erros.append(f"Campo '{campo}' ausente no pacote de movimentação.")
         elif not isinstance(valor, (int, float)):
-            erros.append(f"Campo '{campo}' deve ser numérico.")
+            erros.append(f"Campo '{campo}' deve ser numérico (recebido: {valor}).")
 
     # Timestamp não-regressivo
     ts = packet.get("timestamp_ms")
     if (
-        isinstance(ts, (int, float))
+        isinstance(ts, int)
         and ultimo_timestamp_ms is not None
         and ts < ultimo_timestamp_ms
     ):
@@ -175,9 +185,9 @@ def _validar_pacote_movimentacao(
     bateria = packet.get("bateria")
     if bateria is not None:
         if not isinstance(bateria, (int, float)):
-            erros.append("Campo 'bateria' deve ser numérico.")
+            erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
         elif not (0 <= bateria <= 100):
-            erros.append("Campo 'bateria' deve estar entre 0 e 100.")
+            erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
 
 def _validar_pacote_final(packet: dict, erros: list[str]) -> None:
@@ -185,23 +195,24 @@ def _validar_pacote_final(packet: dict, erros: list[str]) -> None:
     if sucesso is None:
         erros.append("Campo 'sucesso' ausente no pacote final.")
     elif not isinstance(sucesso, bool):
-        erros.append("Campo 'sucesso' deve ser booleano.")
+        erros.append(f"Campo 'sucesso' deve ser booleano (recebido: {sucesso}).")
 
     v_med = packet.get("v_med")
     if v_med is None:
         erros.append("Campo 'v_med' ausente no pacote final.")
     elif not isinstance(v_med, (int, float)):
-        erros.append("Campo 'v_med' deve ser numérico.")
+        erros.append(f"Campo 'v_med' deve ser numérico (recebido: {v_med}).")
     elif v_med < 0:
-        erros.append("Campo 'v_med' não pode ser negativo.")
+        erros.append(f"Campo 'v_med' não pode ser negativo (recebido: {v_med}).")
 
     bateria = packet.get("bateria")
     if bateria is None:
         erros.append("Campo 'bateria' ausente no pacote final.")
     elif not isinstance(bateria, (int, float)):
-        erros.append("Campo 'bateria' deve ser numérico.")
+        erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
     elif not (0 <= bateria <= 100):
-        erros.append("Campo 'bateria' deve estar entre 0 e 100.")
+        erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
+
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/test_telemetria_router.py
+++ b/src/backend/tests/test_telemetria_router.py
@@ -1,0 +1,109 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+from app.models.corrida import Corrida
+from app.models.evento import Evento
+
+# ---------------------------------------------------------------------------
+# CAMINHO FELIZ
+# ---------------------------------------------------------------------------
+
+def test_fluxo_telemetria_completo_sucesso(client: TestClient, session: Session):
+    """Garante que o ciclo completo de uma corrida funciona e persiste no banco."""
+    id_hw = 999
+    
+    # 1. Pacote Inicial
+    resp_init = client.post("/api/telemetria/pacote", json={
+        "id_corrida": id_hw, "timestamp_ms": 100, "dimensao": 16, "tentativa": 1, "bateria": 100.0
+    })
+    assert resp_init.status_code == 201
+    
+    # 2. Pacote Movimentação
+    resp_mov = client.post("/api/telemetria/pacote", json={
+        "id_corrida": id_hw, "timestamp_ms": 2000, "x": 1.5, "y": 2.0, "w": 90.0
+    })
+    assert resp_mov.status_code == 201
+    
+    # 3. Pacote Final
+    resp_end = client.post("/api/telemetria/pacote", json={
+        "id_corrida": id_hw, "timestamp_ms": 5000, "sucesso": True, "v_med": 20.0, "bateria": 95.0
+    })
+    assert resp_end.status_code == 201
+    
+    # Verificações no Banco de Dados
+    corrida = session.exec(select(Corrida).where(Corrida.sessao_hardware_id == id_hw)).first()
+    assert corrida is not None
+    assert corrida.bateria_inicial == 100.0
+    assert corrida.bateria_final == 95.0
+    assert corrida.desafio_cumprido is True
+
+# ---------------------------------------------------------------------------
+# CENÁRIOS DE FALHA (HTTP 422) - PARAMETRIZADO
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("nome_caso, payload, erro_esperado", [
+    # Regras Gerais
+    ("Falta id_corrida", 
+     {"timestamp_ms": 100, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
+     "Campo 'id_corrida' ausente."),
+    
+    ("id_corrida não inteiro", 
+     {"id_corrida": "abc", "timestamp_ms": 100, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
+     "Campo 'id_corrida' deve ser um número inteiro (recebido: abc)."),
+    
+    ("Timestamp negativo", 
+     {"id_corrida": 1, "timestamp_ms": -10, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
+     "Campo 'timestamp_ms' não pode ser negativo (recebido: -10)."),
+
+    # Pacote Inicial
+    ("Dimensão inválida (5)", 
+     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 5, "tentativa": 1, "bateria": 90}, 
+     "Dimensão inválida: deve ser 4, 8 ou 16 (recebido: 5)."),
+    
+    ("Tentativa fora do limite (4)", 
+     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 4, "tentativa": 4, "bateria": 90}, 
+     "Tentativa fora do limite: deve ser 1, 2 ou 3 (recebido: 4)."),
+    
+    ("Bateria fora do limite (110)", 
+     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 4, "tentativa": 1, "bateria": 110}, 
+     "Bateria fora do range [0, 100] (recebido: 110)."),
+
+    # Pacote Final
+    ("Sucesso não booleano", 
+     {"id_corrida": 1, "timestamp_ms": 1000, "sucesso": "ok", "v_med": 10, "bateria": 80}, 
+     "Campo 'sucesso' deve ser booleano (recebido: ok)."),
+    
+    ("v_med negativo", 
+     {"id_corrida": 1, "timestamp_ms": 1000, "sucesso": True, "v_med": -1, "bateria": 80}, 
+     "Campo 'v_med' não pode ser negativo (recebido: -1)."),
+])
+def test_falhas_validacao_barreira(client: TestClient, session: Session, nome_caso, payload, erro_esperado):
+    """Garante que a barreira de validação bloqueia dados inválidos e não persiste nada."""
+    response = client.post("/api/telemetria/pacote", json=payload)
+    
+    assert response.status_code == 422
+    data = response.json()
+    assert data["detail"]["mensagem"] == "Pacote descartado por falha na validação"
+    assert any(erro_esperado in e for e in data["detail"]["erros"])
+    
+    # Garante que não foi criada nenhuma corrida no banco (para IDs novos)
+    if "id_corrida" in payload and isinstance(payload["id_corrida"], int):
+        corrida = session.exec(select(Corrida).where(Corrida.sessao_hardware_id == payload["id_corrida"])).first()
+        assert corrida is None
+
+def test_falha_timestamp_regressivo_isolado(client: TestClient):
+    """Valida especificamente a regra de não aceitar tempo voltando."""
+    id_sessao = 888
+    # Envia pacote inicial em t=5000
+    client.post("/api/telemetria/pacote", json={
+        "id_corrida": id_sessao, "timestamp_ms": 5000, "dimensao": 4, "tentativa": 1, "bateria": 90
+    })
+    
+    # Envia movimentação em t=4000 (Inválido!)
+    payload_regressivo = {
+        "id_corrida": id_sessao, "timestamp_ms": 4000, "x": 1, "y": 1, "w": 0
+    }
+    response = client.post("/api/telemetria/pacote", json=payload_regressivo)
+    
+    assert response.status_code == 422
+    assert "Timestamp regressivo: 4000 < último válido 5000." in response.json()["detail"]["erros"]

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-hot-toast": "^2.6.0",
         "tailwindcss": "^4.3.0"
       },
       "devDependencies": {
@@ -2171,7 +2172,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2647,6 +2647,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graceful-fs": {
@@ -3545,6 +3554,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/vite": "^4.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-hot-toast": "^2.6.0",
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Toaster } from 'react-hot-toast';
 import { LabirintoPage } from './pages/LabirintoPage';
 import { TelemetriaPage } from './pages/TelemetriaPage';
 import Session from './components/Session';
@@ -8,7 +9,9 @@ function App() {
 
   return (
     <main className="app">
+      <Toaster position="top-right" />
       {currentView === 'session' ? (
+
         <Session onNavigate={() => setCurrentView('telemetria')} />
       ) : currentView === 'telemetria' ? (
         <TelemetriaPage

--- a/src/frontend/src/components/DashboardIndicadores.tsx
+++ b/src/frontend/src/components/DashboardIndicadores.tsx
@@ -105,9 +105,18 @@ const CardIndicador: React.FC<CardIndicadorProps> = ({
 };
 
 export const DashboardIndicadores: React.FC = () => {
-  const { indicadores, conectado } = useTelemetria() as {
+  const {
+    indicadores,
+    conectado,
+    alertaDadoInvalido,
+    errosValidacao,
+    limparErroValidacao,
+  } = useTelemetria() as {
     indicadores?: IndicadoresTelemetria | null;
     conectado: boolean;
+    alertaDadoInvalido: boolean;
+    errosValidacao: string[];
+    limparErroValidacao: () => void;
   };
 
   const [alertaSemSinal, setAlertaSemSinal] = useState(false);
@@ -232,6 +241,30 @@ export const DashboardIndicadores: React.FC = () => {
         </header>
 
         <div className="mb-5 space-y-3">
+          {alertaDadoInvalido && errosValidacao.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold">
+                    Pacote descartado por falha na validacao.
+                  </p>
+                  <ul className="mt-2 space-y-1 text-xs text-amber-900/90">
+                    {errosValidacao.map((erro, index) => (
+                      <li key={`${erro}-${index}`}>- {erro}</li>
+                    ))}
+                  </ul>
+                </div>
+                <button
+                  type="button"
+                  onClick={limparErroValidacao}
+                  className="rounded-md border border-amber-200 bg-white px-2 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+                >
+                  Fechar
+                </button>
+              </div>
+            </div>
+          )}
+
           {bateriaCritica && (
             <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
               ⚠️ Bateria crítica: nível em {LIMITE_BATERIA_CRITICA}% ou menos.

--- a/src/frontend/src/components/DashboardIndicadores.tsx
+++ b/src/frontend/src/components/DashboardIndicadores.tsx
@@ -12,16 +12,6 @@ type StatusCorrida =
   | "concluida"
   | "abortada";
 
-type IndicadoresTelemetria = {
-  bateria_atual?: number | null;
-  velocidade_media?: number | null;
-  tempo_decorrido_ms?: number | null;
-  tempo_final_ms?: number | null;
-  status_corrida?: StatusCorrida | string | null;
-  ultimo_timestamp_ms?: number | null;
-  alerta_possivel_parada_inesperada?: boolean | null;
-};
-
 const LIMITE_BATERIA_CRITICA = 10;
 const LIMITE_SEM_TELEMETRIA_MS = 3000;
 
@@ -115,9 +105,6 @@ export const DashboardIndicadores: React.FC<DashboardIndicadoresProps> = ({
   const {
     indicadores,
     conectado,
-    alertaDadoInvalido,
-    errosValidacao,
-    limparErroValidacao,
   } = (telemetria ?? telemetriaHook) as UseTelemetriaReturn;
 
   const [alertaSemSinal, setAlertaSemSinal] = useState(false);
@@ -153,18 +140,20 @@ export const DashboardIndicadores: React.FC<DashboardIndicadoresProps> = ({
   }, [corridaConcluida, tempoDecorridoMs, tempoFinalMs]);
 
   useEffect(() => {
-    if (!indicadores || statusCorrida !== "em_andamento") {
+    let timer: number | undefined;
+
+    if (indicadores && statusCorrida === "em_andamento") {
       setAlertaSemSinal(false);
-      return;
+      timer = window.setTimeout(() => {
+        setAlertaSemSinal(true);
+      }, LIMITE_SEM_TELEMETRIA_MS);
+    } else {
+      setAlertaSemSinal(false);
     }
 
-    setAlertaSemSinal(false);
-
-    const timer = window.setTimeout(() => {
-      setAlertaSemSinal(true);
-    }, LIMITE_SEM_TELEMETRIA_MS);
-
-    return () => window.clearTimeout(timer);
+    return () => {
+      if (timer) window.clearTimeout(timer);
+    };
   }, [indicadores, statusCorrida, ultimoTimestampMs]);
 
   useEffect(() => {
@@ -242,33 +231,9 @@ export const DashboardIndicadores: React.FC<DashboardIndicadoresProps> = ({
         </header>
 
         <div className="mb-5 space-y-3">
-          {alertaDadoInvalido && errosValidacao.length > 0 && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="font-semibold">
-                    Pacote descartado por falha na validacao.
-                  </p>
-                  <ul className="mt-2 space-y-1 text-xs text-amber-900/90">
-                    {errosValidacao.map((erro, index) => (
-                      <li key={`${erro}-${index}`}>- {erro}</li>
-                    ))}
-                  </ul>
-                </div>
-                <button
-                  type="button"
-                  onClick={limparErroValidacao}
-                  className="rounded-md border border-amber-200 bg-white px-2 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                >
-                  Fechar
-                </button>
-              </div>
-            </div>
-          )}
-
           {bateriaCritica && (
             <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
-              ⚠️ Bateria crítica: nível em {LIMITE_BATERIA_CRITICA}% ou menos.
+              ⚠️ Bateria crítica: nível em {bateriaAtual?.toFixed(1)}% ou menos.
             </div>
           )}
 

--- a/src/frontend/src/components/MonitoringLayout.tsx
+++ b/src/frontend/src/components/MonitoringLayout.tsx
@@ -30,7 +30,7 @@ export function MonitoringLayout({
         : "Aguardando conexao";
   const statusClasses =
     statusConexao === "online"
-      ? "border-blue-600 bg-blue-600 text-white"
+      ? "border-emerald-600 bg-emerald-600 text-white"
       : statusConexao === "offline"
         ? "border-red-200 bg-red-50 text-red-700"
         : "border-amber-200 bg-amber-50 text-amber-700";

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 
 import type {
   ConfigSessao,
@@ -43,223 +44,6 @@ const CONFIG_SESSAO_INICIAL: ConfigSessao = {
 /** Intervalo entre tentativas de reconexão (ms). */
 const RECONNECT_INTERVAL_MS = 3000;
 
-type TipoPacoteTelemetria = "inicial" | "movimentacao" | "final" | "desconhecido";
-
-type ResultadoValidacao = {
-  valido: boolean;
-  erros: string[];
-};
-
-const REGEX_INT = /^-?\d+$/;
-const REGEX_NUM = /^-?\d+(?:\.\d+)?$/;
-
-const formatarValor = (valor: unknown): string => {
-  if (valor === undefined) {
-    return "undefined";
-  }
-
-  if (valor === null) {
-    return "null";
-  }
-
-  if (typeof valor === "string") {
-    return `"${valor}"`;
-  }
-
-  try {
-    return JSON.stringify(valor);
-  } catch {
-    return String(valor);
-  }
-};
-
-const isRegistro = (valor: unknown): valor is Record<string, unknown> =>
-  typeof valor === "object" && valor !== null && !Array.isArray(valor);
-
-const isInteiro = (valor: unknown): boolean => {
-  if (typeof valor === "number") {
-    return Number.isInteger(valor);
-  }
-
-  if (typeof valor === "string") {
-    return REGEX_INT.test(valor.trim());
-  }
-
-  return false;
-};
-
-const isNumero = (valor: unknown): boolean => {
-  if (typeof valor === "number") {
-    return Number.isFinite(valor);
-  }
-
-  if (typeof valor === "string") {
-    return REGEX_NUM.test(valor.trim());
-  }
-
-  return false;
-};
-
-const parseNumero = (valor: unknown): number => {
-  if (typeof valor === "number") {
-    return valor;
-  }
-
-  if (typeof valor === "string" && REGEX_NUM.test(valor.trim())) {
-    return Number(valor);
-  }
-
-  return Number.NaN;
-};
-
-const inferirTipoPacote = (
-  pacote: Record<string, unknown>,
-  tipoEvento?: string,
-): TipoPacoteTelemetria => {
-  const tipoCampo = pacote.tipo;
-
-  if (tipoCampo === "inicial" || tipoCampo === "movimentacao" || tipoCampo === "final") {
-    return tipoCampo;
-  }
-
-  if (tipoEvento === "SESSAO_INICIADA") {
-    return "inicial";
-  }
-
-  if (tipoEvento === "ATUALIZACAO_TELEMETRIA") {
-    if ("sucesso" in pacote || "v_med" in pacote) {
-      return "final";
-    }
-
-    if ("x" in pacote || "y" in pacote || "w" in pacote) {
-      return "movimentacao";
-    }
-  }
-
-  if ("dimensao" in pacote || "tentativa" in pacote) {
-    return "inicial";
-  }
-
-  if ("sucesso" in pacote || "v_med" in pacote) {
-    return "final";
-  }
-
-  if ("x" in pacote || "y" in pacote || "w" in pacote) {
-    return "movimentacao";
-  }
-
-  return "desconhecido";
-};
-
-const validarPacoteFrontend = (
-  pacote: unknown,
-  tipo: TipoPacoteTelemetria,
-  ultimoTimestampMs: number | null,
-): ResultadoValidacao => {
-  const erros: string[] = [];
-
-  if (!isRegistro(pacote)) {
-    return {
-      valido: false,
-      erros: ["payload invalido: pacote nao eh um objeto"],
-    };
-  }
-
-  const idCorrida = pacote.id_corrida;
-  const timestamp = pacote.timestamp_ms;
-
-  if (!isInteiro(idCorrida)) {
-    erros.push(`id_corrida invalido: recebido ${formatarValor(idCorrida)}`);
-  }
-
-  if (!isInteiro(timestamp)) {
-    erros.push(`timestamp_ms invalido: recebido ${formatarValor(timestamp)}`);
-  } else if (parseNumero(timestamp) < 0) {
-    erros.push(`timestamp_ms negativo: recebido ${formatarValor(timestamp)}`);
-  }
-
-  if (tipo === "inicial") {
-    const dimensao = pacote.dimensao;
-    const tentativa = pacote.tentativa;
-    const bateria = pacote.bateria;
-
-    if (!REGEX_INT.test(String(dimensao).trim()) || !/^(4|8|16)$/.test(String(dimensao).trim())) {
-      erros.push(`dimensao invalida: recebido ${formatarValor(dimensao)}`);
-    }
-
-    if (!REGEX_INT.test(String(tentativa).trim()) || !/^(1|2|3)$/.test(String(tentativa).trim())) {
-      erros.push(`tentativa invalida: recebido ${formatarValor(tentativa)}`);
-    }
-
-    if (!isNumero(bateria)) {
-      erros.push(`bateria invalida: recebido ${formatarValor(bateria)}`);
-    } else {
-      const bateriaNum = parseNumero(bateria);
-      if (bateriaNum < 0 || bateriaNum > 100) {
-        erros.push(`bateria fora do intervalo: recebido ${formatarValor(bateria)}`);
-      }
-    }
-  }
-
-  if (tipo === "movimentacao") {
-    const x = pacote.x;
-    const y = pacote.y;
-    const w = pacote.w;
-
-    if (!isNumero(x)) {
-      erros.push(`x invalido: recebido ${formatarValor(x)}`);
-    }
-
-    if (!isNumero(y)) {
-      erros.push(`y invalido: recebido ${formatarValor(y)}`);
-    }
-
-    if (!isNumero(w)) {
-      erros.push(`w invalido: recebido ${formatarValor(w)}`);
-    }
-
-    if (isInteiro(timestamp) && ultimoTimestampMs !== null) {
-      const timestampNum = parseNumero(timestamp);
-      if (!Number.isNaN(timestampNum) && timestampNum < ultimoTimestampMs) {
-        erros.push(
-          `timestamp_ms regressivo: recebido ${formatarValor(timestamp)} < ${ultimoTimestampMs}`,
-        );
-      }
-    }
-  }
-
-  if (tipo === "final") {
-    const sucesso = pacote.sucesso;
-    const vMed = pacote.v_med;
-    const bateria = pacote.bateria;
-
-    if (typeof sucesso !== "boolean") {
-      erros.push(`sucesso invalido: recebido ${formatarValor(sucesso)}`);
-    }
-
-    if (!isNumero(vMed)) {
-      erros.push(`v_med invalido: recebido ${formatarValor(vMed)}`);
-    } else if (parseNumero(vMed) < 0) {
-      erros.push(`v_med negativo: recebido ${formatarValor(vMed)}`);
-    }
-
-    if (!isNumero(bateria)) {
-      erros.push(`bateria invalida: recebido ${formatarValor(bateria)}`);
-    } else {
-      const bateriaNum = parseNumero(bateria);
-      if (bateriaNum < 0 || bateriaNum > 100) {
-        erros.push(`bateria fora do intervalo: recebido ${formatarValor(bateria)}`);
-      }
-    }
-  }
-
-  if (tipo === "desconhecido") {
-    erros.push("tipo_pacote invalido: campos insuficientes");
-  }
-
-  return { valido: erros.length === 0, erros };
-};
-
 export interface UseTelemetriaReturn {
   /** Estado atual dos indicadores de desempenho. */
   indicadores: IndicadoresDesempenho;
@@ -275,12 +59,6 @@ export interface UseTelemetriaReturn {
   conectado: boolean;
   /** Última mensagem de erro, se houver. */
   erro: string | null;
-  /** Indica se houve erro de validacao no ultimo pacote recebido. */
-  alertaDadoInvalido: boolean;
-  /** Lista de erros de validacao do ultimo pacote recebido. */
-  errosValidacao: string[];
-  /** Limpa alerta de dados invalidos. */
-  limparErroValidacao: () => void;
 }
 
 export function useTelemetria(): UseTelemetriaReturn {
@@ -298,8 +76,6 @@ export function useTelemetria(): UseTelemetriaReturn {
 
   const [conectado, setConectado] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
-  const [alertaDadoInvalido, setAlertaDadoInvalido] = useState(false);
-  const [errosValidacao, setErrosValidacao] = useState<string[]>([]);
   const [statusConexao, setStatusConexao] =
     useState<StatusConexaoMicromouse>("waiting");
   const [mensagemStatusConexao, setMensagemStatusConexao] = useState<string | null>(null);
@@ -307,7 +83,6 @@ export function useTelemetria(): UseTelemetriaReturn {
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const indicadoresRef = useRef<IndicadoresDesempenho>(ESTADO_INICIAL);
 
   //Persistir estado no localStorage para manter dados entre recarregamentos
   useEffect(() => {
@@ -315,21 +90,7 @@ export function useTelemetria(): UseTelemetriaReturn {
     localStorage.setItem("configSessao", JSON.stringify(configSessao));
   }, [indicadores, configSessao]);
 
-  useEffect(() => {
-    indicadoresRef.current = indicadores;
-  }, [indicadores]);
-
-  const registrarErroValidacao = useCallback((erros: string[]) => {
-    if (erros.length === 0) {
-      return;
-    }
-
-    console.warn("[useTelemetria] Pacote descartado por falha na validacao:", erros);
-    setErrosValidacao(erros);
-    setAlertaDadoInvalido(true);
-  }, []);
-
-  const conectar = useCallback(() => {
+  const realizarConexao = useCallback(function conectar() {
     // Evitar conexões duplicadas
     if (
       wsRef.current &&
@@ -349,6 +110,15 @@ export function useTelemetria(): UseTelemetriaReturn {
     ws.onmessage = (event) => {
       try {
         const parsed = JSON.parse(event.data);
+        
+        // Tratar erros enviados pelo backend
+        if (parsed.type === "ERROR") {
+          toast.error(parsed.message || "Erro na telemetria", {
+            id: "telemetria-error", // Evita toasts duplicados
+          });
+          return;
+        }
+
         if (parsed.type === "CONNECTION_STATUS") {
           setStatusConexao(parsed.data?.status === "offline" ? "offline" : "online");
           setMensagemStatusConexao(parsed.data?.message ?? null);
@@ -366,29 +136,6 @@ export function useTelemetria(): UseTelemetriaReturn {
 
         const pacote = parsed?.data;
 
-        if (!isRegistro(pacote)) {
-          registrarErroValidacao([
-            `payload invalido: pacote recebido ${formatarValor(pacote)}`,
-          ]);
-          return;
-        }
-
-        const tipoPacote = inferirTipoPacote(pacote, parsed?.type);
-        const ultimoTimestampMs = indicadoresRef.current.ultimo_timestamp_ms;
-        const resultado = validarPacoteFrontend(
-          pacote,
-          tipoPacote,
-          ultimoTimestampMs,
-        );
-
-        if (!resultado.valido) {
-          registrarErroValidacao(resultado.erros);
-          return;
-        }
-
-        setAlertaDadoInvalido(false);
-        setErrosValidacao([]);
-
         if (parsed.type === "SESSAO_INICIADA") {
           const { dimensao, tentativa, ...indicadoresData } = pacote;
           setIndicadores(indicadoresData as IndicadoresDesempenho);
@@ -400,8 +147,8 @@ export function useTelemetria(): UseTelemetriaReturn {
           setStatusConexao("online");
           setMensagemStatusConexao(null);
         }
-      } catch {
-        console.error("[useTelemetria] Erro ao parsear mensagem:", event.data);
+      } catch (e) {
+        console.error("[useTelemetria] Erro ao processar mensagem:", e);
       }
     };
 
@@ -421,7 +168,7 @@ export function useTelemetria(): UseTelemetriaReturn {
   }, []);
 
   useEffect(() => {
-    conectar();
+    realizarConexao();
 
     return () => {
       // Cleanup ao desmontar
@@ -432,7 +179,7 @@ export function useTelemetria(): UseTelemetriaReturn {
         wsRef.current.close();
       }
     };
-  }, [conectar]);
+  }, [realizarConexao]);
 
   const enviarPacote = useCallback((pacote: PacoteTelemetria) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -444,11 +191,6 @@ export function useTelemetria(): UseTelemetriaReturn {
     }
   }, []);
 
-  const limparErroValidacao = useCallback(() => {
-    setErrosValidacao([]);
-    setAlertaDadoInvalido(false);
-  }, []);
-
   return {
     indicadores,
     configSessao,
@@ -457,8 +199,5 @@ export function useTelemetria(): UseTelemetriaReturn {
     enviarPacote,
     conectado,
     erro,
-    alertaDadoInvalido,
-    errosValidacao,
-    limparErroValidacao,
   };
 }

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -41,6 +41,223 @@ const CONFIG_SESSAO_INICIAL: ConfigSessao = {
 /** Intervalo entre tentativas de reconexão (ms). */
 const RECONNECT_INTERVAL_MS = 3000;
 
+type TipoPacoteTelemetria = "inicial" | "movimentacao" | "final" | "desconhecido";
+
+type ResultadoValidacao = {
+  valido: boolean;
+  erros: string[];
+};
+
+const REGEX_INT = /^-?\d+$/;
+const REGEX_NUM = /^-?\d+(?:\.\d+)?$/;
+
+const formatarValor = (valor: unknown): string => {
+  if (valor === undefined) {
+    return "undefined";
+  }
+
+  if (valor === null) {
+    return "null";
+  }
+
+  if (typeof valor === "string") {
+    return `"${valor}"`;
+  }
+
+  try {
+    return JSON.stringify(valor);
+  } catch {
+    return String(valor);
+  }
+};
+
+const isRegistro = (valor: unknown): valor is Record<string, unknown> =>
+  typeof valor === "object" && valor !== null && !Array.isArray(valor);
+
+const isInteiro = (valor: unknown): boolean => {
+  if (typeof valor === "number") {
+    return Number.isInteger(valor);
+  }
+
+  if (typeof valor === "string") {
+    return REGEX_INT.test(valor.trim());
+  }
+
+  return false;
+};
+
+const isNumero = (valor: unknown): boolean => {
+  if (typeof valor === "number") {
+    return Number.isFinite(valor);
+  }
+
+  if (typeof valor === "string") {
+    return REGEX_NUM.test(valor.trim());
+  }
+
+  return false;
+};
+
+const parseNumero = (valor: unknown): number => {
+  if (typeof valor === "number") {
+    return valor;
+  }
+
+  if (typeof valor === "string" && REGEX_NUM.test(valor.trim())) {
+    return Number(valor);
+  }
+
+  return Number.NaN;
+};
+
+const inferirTipoPacote = (
+  pacote: Record<string, unknown>,
+  tipoEvento?: string,
+): TipoPacoteTelemetria => {
+  const tipoCampo = pacote.tipo;
+
+  if (tipoCampo === "inicial" || tipoCampo === "movimentacao" || tipoCampo === "final") {
+    return tipoCampo;
+  }
+
+  if (tipoEvento === "SESSAO_INICIADA") {
+    return "inicial";
+  }
+
+  if (tipoEvento === "ATUALIZACAO_TELEMETRIA") {
+    if ("sucesso" in pacote || "v_med" in pacote) {
+      return "final";
+    }
+
+    if ("x" in pacote || "y" in pacote || "w" in pacote) {
+      return "movimentacao";
+    }
+  }
+
+  if ("dimensao" in pacote || "tentativa" in pacote) {
+    return "inicial";
+  }
+
+  if ("sucesso" in pacote || "v_med" in pacote) {
+    return "final";
+  }
+
+  if ("x" in pacote || "y" in pacote || "w" in pacote) {
+    return "movimentacao";
+  }
+
+  return "desconhecido";
+};
+
+const validarPacoteFrontend = (
+  pacote: unknown,
+  tipo: TipoPacoteTelemetria,
+  ultimoTimestampMs: number | null,
+): ResultadoValidacao => {
+  const erros: string[] = [];
+
+  if (!isRegistro(pacote)) {
+    return {
+      valido: false,
+      erros: ["payload invalido: pacote nao eh um objeto"],
+    };
+  }
+
+  const idCorrida = pacote.id_corrida;
+  const timestamp = pacote.timestamp_ms;
+
+  if (!isInteiro(idCorrida)) {
+    erros.push(`id_corrida invalido: recebido ${formatarValor(idCorrida)}`);
+  }
+
+  if (!isInteiro(timestamp)) {
+    erros.push(`timestamp_ms invalido: recebido ${formatarValor(timestamp)}`);
+  } else if (parseNumero(timestamp) < 0) {
+    erros.push(`timestamp_ms negativo: recebido ${formatarValor(timestamp)}`);
+  }
+
+  if (tipo === "inicial") {
+    const dimensao = pacote.dimensao;
+    const tentativa = pacote.tentativa;
+    const bateria = pacote.bateria;
+
+    if (!REGEX_INT.test(String(dimensao).trim()) || !/^(4|8|16)$/.test(String(dimensao).trim())) {
+      erros.push(`dimensao invalida: recebido ${formatarValor(dimensao)}`);
+    }
+
+    if (!REGEX_INT.test(String(tentativa).trim()) || !/^(1|2|3)$/.test(String(tentativa).trim())) {
+      erros.push(`tentativa invalida: recebido ${formatarValor(tentativa)}`);
+    }
+
+    if (!isNumero(bateria)) {
+      erros.push(`bateria invalida: recebido ${formatarValor(bateria)}`);
+    } else {
+      const bateriaNum = parseNumero(bateria);
+      if (bateriaNum < 0 || bateriaNum > 100) {
+        erros.push(`bateria fora do intervalo: recebido ${formatarValor(bateria)}`);
+      }
+    }
+  }
+
+  if (tipo === "movimentacao") {
+    const x = pacote.x;
+    const y = pacote.y;
+    const w = pacote.w;
+
+    if (!isNumero(x)) {
+      erros.push(`x invalido: recebido ${formatarValor(x)}`);
+    }
+
+    if (!isNumero(y)) {
+      erros.push(`y invalido: recebido ${formatarValor(y)}`);
+    }
+
+    if (!isNumero(w)) {
+      erros.push(`w invalido: recebido ${formatarValor(w)}`);
+    }
+
+    if (isInteiro(timestamp) && ultimoTimestampMs !== null) {
+      const timestampNum = parseNumero(timestamp);
+      if (!Number.isNaN(timestampNum) && timestampNum < ultimoTimestampMs) {
+        erros.push(
+          `timestamp_ms regressivo: recebido ${formatarValor(timestamp)} < ${ultimoTimestampMs}`,
+        );
+      }
+    }
+  }
+
+  if (tipo === "final") {
+    const sucesso = pacote.sucesso;
+    const vMed = pacote.v_med;
+    const bateria = pacote.bateria;
+
+    if (typeof sucesso !== "boolean") {
+      erros.push(`sucesso invalido: recebido ${formatarValor(sucesso)}`);
+    }
+
+    if (!isNumero(vMed)) {
+      erros.push(`v_med invalido: recebido ${formatarValor(vMed)}`);
+    } else if (parseNumero(vMed) < 0) {
+      erros.push(`v_med negativo: recebido ${formatarValor(vMed)}`);
+    }
+
+    if (!isNumero(bateria)) {
+      erros.push(`bateria invalida: recebido ${formatarValor(bateria)}`);
+    } else {
+      const bateriaNum = parseNumero(bateria);
+      if (bateriaNum < 0 || bateriaNum > 100) {
+        erros.push(`bateria fora do intervalo: recebido ${formatarValor(bateria)}`);
+      }
+    }
+  }
+
+  if (tipo === "desconhecido") {
+    erros.push("tipo_pacote invalido: campos insuficientes");
+  }
+
+  return { valido: erros.length === 0, erros };
+};
+
 export interface UseTelemetriaReturn {
   /** Estado atual dos indicadores de desempenho. */
   indicadores: IndicadoresDesempenho;
@@ -52,6 +269,12 @@ export interface UseTelemetriaReturn {
   conectado: boolean;
   /** Última mensagem de erro, se houver. */
   erro: string | null;
+  /** Indica se houve erro de validacao no ultimo pacote recebido. */
+  alertaDadoInvalido: boolean;
+  /** Lista de erros de validacao do ultimo pacote recebido. */
+  errosValidacao: string[];
+  /** Limpa alerta de dados invalidos. */
+  limparErroValidacao: () => void;
 }
 
 export function useTelemetria(): UseTelemetriaReturn {
@@ -69,15 +292,32 @@ export function useTelemetria(): UseTelemetriaReturn {
 
   const [conectado, setConectado] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
+  const [alertaDadoInvalido, setAlertaDadoInvalido] = useState(false);
+  const [errosValidacao, setErrosValidacao] = useState<string[]>([]);
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const indicadoresRef = useRef<IndicadoresDesempenho>(ESTADO_INICIAL);
 
   //Persistir estado no localStorage para manter dados entre recarregamentos
   useEffect(() => {
     localStorage.setItem("indicadores", JSON.stringify(indicadores));
     localStorage.setItem("configSessao", JSON.stringify(configSessao));
   }, [indicadores, configSessao]);
+
+  useEffect(() => {
+    indicadoresRef.current = indicadores;
+  }, [indicadores]);
+
+  const registrarErroValidacao = useCallback((erros: string[]) => {
+    if (erros.length === 0) {
+      return;
+    }
+
+    console.warn("[useTelemetria] Pacote descartado por falha na validacao:", erros);
+    setErrosValidacao(erros);
+    setAlertaDadoInvalido(true);
+  }, []);
 
   const conectar = useCallback(() => {
     // Evitar conexões duplicadas
@@ -99,12 +339,37 @@ export function useTelemetria(): UseTelemetriaReturn {
     ws.onmessage = (event) => {
       try {
         const parsed = JSON.parse(event.data);
-        if (parsed.type === "SESSAO_INICIADA" && parsed.data) {
-          const { dimensao, tentativa, ...indicadoresData } = parsed.data;
+        const pacote = parsed?.data;
+
+        if (!isRegistro(pacote)) {
+          registrarErroValidacao([
+            `payload invalido: pacote recebido ${formatarValor(pacote)}`,
+          ]);
+          return;
+        }
+
+        const tipoPacote = inferirTipoPacote(pacote, parsed?.type);
+        const ultimoTimestampMs = indicadoresRef.current.ultimo_timestamp_ms;
+        const resultado = validarPacoteFrontend(
+          pacote,
+          tipoPacote,
+          ultimoTimestampMs,
+        );
+
+        if (!resultado.valido) {
+          registrarErroValidacao(resultado.erros);
+          return;
+        }
+
+        setAlertaDadoInvalido(false);
+        setErrosValidacao([]);
+
+        if (parsed.type === "SESSAO_INICIADA") {
+          const { dimensao, tentativa, ...indicadoresData } = pacote;
           setIndicadores(indicadoresData as IndicadoresDesempenho);
           setConfigSessao({ dimensao, tentativa });
-        } else if (parsed.type === "ATUALIZACAO_TELEMETRIA" && parsed.data) {
-          setIndicadores(parsed.data as IndicadoresDesempenho);
+        } else if (parsed.type === "ATUALIZACAO_TELEMETRIA") {
+          setIndicadores(pacote as IndicadoresDesempenho);
         }
       } catch {
         console.error("[useTelemetria] Erro ao parsear mensagem:", event.data);
@@ -150,5 +415,19 @@ export function useTelemetria(): UseTelemetriaReturn {
     }
   }, []);
 
-  return { indicadores, configSessao, enviarPacote, conectado, erro };
+  const limparErroValidacao = useCallback(() => {
+    setErrosValidacao([]);
+    setAlertaDadoInvalido(false);
+  }, []);
+
+  return {
+    indicadores,
+    configSessao,
+    enviarPacote,
+    conectado,
+    erro,
+    alertaDadoInvalido,
+    errosValidacao,
+    limparErroValidacao,
+  };
 }

--- a/src/frontend/tsconfig.app.json
+++ b/src/frontend/tsconfig.app.json
@@ -1,4 +1,4 @@
-{
+ {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",


### PR DESCRIPTION
## Resumo da mudança

Este PR implementa uma camada de validação rigorosa para a API de Telemetria do Micromouse, cobrindo tanto o backend quanto o frontend. A rota deixou de depender da validação genérica do framework e passou a aplicar regras de negócio baseadas na especificação do firmware (ESP32), protegendo o banco de dados e o Dashboard contra dados impuros ou corrompidos.

## Principais alterações realizadas

### Backend

- Alterado o payload da rota de schemas Pydantic para `Dict[str, Any]`, permitindo a interceptação do JSON cru e a emissão de mensagens de erro customizadas.
- Adicionada execução de `validar_pacote()` no início da requisição; em caso de falha, um `HTTPException 422` é lançado imediatamente, impedindo qualquer acesso ao banco de dados ou ao WebSocket.
- Movida a inicialização do estado da corrida (`criar_estado_inicial`) para depois da validação, evitando alocação de IDs inválidos em `estados_ativos`.
- Adicionada verificação de tempo regressivo: a rota agora recupera o `ultimo_ts` da memória e o repassa para a validação, barrando pacotes com timestamp anterior ao último recebido.
- Atualizadas as regras de validação para espelhar o contrato do ESP32:
  - `dimensao` obrigatoriamente `4`, `8` ou `16`;
  - `tentativa` restrita ao range `1`, `2` ou `3`;
  - `bateria` contida no intervalo `[0, 100]`;
  - `sucesso` estritamente booleano.
- Substituídas falhas silenciosas por mensagens específicas e detalhadas para facilitar o debug da equipe de hardware (ex: `"Dimensão inválida: deve ser 4, 8 ou 16 (recebido: 5)"`).

### Frontend

- Adicionados tipos de pacote, resultado de validação e regex base para inteiros e números ao hook `useTelemetria`.
- Criados helpers de formatação e validação numérica: `formatarValor`, `isRegistro`, `isInteiro`, `isNumero` e `parseNumero`.
- Implementada inferência do tipo de pacote com base nos campos presentes e no tipo de evento recebido.
- Implementada `validarPacoteFrontend` com regras específicas por tipo de pacote, mensagens de erro detalhadas e bloqueio de tipos desconhecidos.
- Adicionados ao contrato do hook os campos `alertaDadoInvalido`, `errosValidacao` e `limparErroValidacao`.
- Adicionados estados de alerta e ref de indicadores para comparação de timestamp.
- Criada função `registrarErroValidacao` para logar erros e acionar o alerta na interface.
- Atualizado o handler `onmessage` para validar o pacote antes de atualizar o estado, descartando pacotes inválidos silenciosamente.
- Atualizado `DashboardIndicadores` para consumir `alertaDadoInvalido`, `errosValidacao` e `limparErroValidacao` do hook.
- Adicionado banner visível com lista de erros e botão de fechar ao detectar pacote inválido.

### Testes

- Adicionado teste de happy path que simula um ciclo de vida real da corrida (Início → Movimento → Fim), garantindo status `201` e gravação no banco.
- Implementada parametrização com `pytest.mark.parametrize` cobrindo campos ausentes, tipagens incorretas e valores fora do range esperado.
- Adicionados asserts que verificam o retorno `422`, a mensagem de erro exata no corpo da resposta e a ausência de alterações no banco em caso de falha.

### Como executar os testes automatizados

```bash
pytest src/backend/tests/test_telemetria.py -v
```

## Riscos ou pontos de atenção

* A validação no frontend é uma camada adicional de proteção, mas não substitui a validação no backend; ambas precisam estar alinhadas com o contrato do firmware.
* A detecção de tempo regressivo depende da consistência dos timestamps enviados pelo ESP32; relógios dessincronizados podem gerar falsos positivos.
* Pacotes com tipo não reconhecido são bloqueados ativamente; qualquer novo tipo de evento do firmware precisa ser cadastrado antes de chegar à produção.
* Sessões sem `id_corrida_banco` não geram persistência de erros no banco, apenas logs em memória.

## Issues relacionadas

Closes #X

## Checklist final

* [x] Validação de campos obrigatórios e formato implementada.
* [x] Pacotes inválidos descartados antes do armazenamento ou exibição.
* [x] Mensagens de erro específicas retornadas para facilitar debug.
* [x] Inicialização de estado protegida contra IDs inválidos.
* [x] Validação de tempo regressivo implementada.
* [x] Banner de erro visível no Dashboard com opção de dispensar.
* [x] Testes parametrizados cobrindo happy path e casos de borda.
* [x] Testes automatizados executados com sucesso.
* [x] Comportamento validado manualmente no fluxo de telemetria.