### PR TITLE
US-20: Implementação de Handshake Estruturado e Auto-Encerramento de Sessões Órfãs

### DIFF
--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -29,10 +29,15 @@ async def websocket_telemetria(websocket: WebSocket):
     O front-end se conecta aqui para ouvir eventos em tempo real.
     """
     await manager.connect(websocket)
-    confirmation_message = {
-        "message": "connected"
+    handshake = {
+        "type": "HANDSHAKE",
+        "data": {
+            "status": "connected",
+            "server_time": datetime.now(UTC).isoformat(),
+            "version": "0.1.0",
+        }
     }
-    await manager.send_json_to_client(confirmation_message, websocket)
+    await manager.send_json_to_client(handshake, websocket)
     try:
         while True:
             await websocket.receive_json()
@@ -64,6 +69,10 @@ async def receber_pacote_telemetria(
     if sessao_hardware_id is None:
         raise HTTPException(
             status_code=400, detail="id_corrida ausente no pacote")
+
+    # Encerrar corridas ativas anteriores se um novo pacote inicial chegar
+    if tipo == TipoPacote.INICIAL and estados_ativos:
+        await _encerrar_corridas_ativas(session, sessao_hardware_id)
 
     # Recupera ou inicializa o estado em memória
     if sessao_hardware_id not in estados_ativos:
@@ -155,6 +164,51 @@ async def receber_pacote_telemetria(
         del estados_ativos[sessao_hardware_id]
         connection_monitor.remover_corrida(sessao_hardware_id)
     return {"message": "Pacote processado com sucesso", "estado": estado_dict}
+
+
+async def _encerrar_corridas_ativas(
+    session: Session,
+    novo_sessao_id: int,
+) -> None:
+    """Encerra corridas ativas quando uma nova sessão é iniciada.
+
+    Garante que apenas uma corrida esteja ativa por vez,
+    encerrando as anteriores com status FALHA no banco de dados.
+    """
+    ids_para_remover = [
+        sid for sid in estados_ativos
+        if sid != novo_sessao_id
+    ]
+
+    if not ids_para_remover:
+        return
+
+    for sid in ids_para_remover:
+        estado = estados_ativos.pop(sid)
+
+        # Atualizar registro no banco se existir
+        if estado.id_corrida_banco is not None:
+            corrida = session.get(Corrida, estado.id_corrida_banco)
+            if corrida and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO:
+                corrida.status_corrida = StatusCorrida.ABORTADA
+                corrida.data_hora_fim = datetime.now(UTC)
+                session.add(corrida)
+
+        connection_monitor.remover_corrida(sid)
+
+    session.commit()
+
+    await manager.send_json_to_all_clients({
+        "type": "SESSAO_ENCERRADA",
+        "data": {
+            "sessoes_encerradas": ids_para_remover,
+            "motivo": "Nova sessão iniciada pelo Micromouse",
+        }
+    })
+
+    logger.info(
+        "Corridas encerradas automaticamente: %s", ids_para_remover
+    )
 
 
 def _estado_to_dict(estado: IndicadoresDesempenho) -> dict:

--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -72,7 +72,7 @@ async def receber_pacote_telemetria(
 
     # Encerrar corridas ativas anteriores se um novo pacote inicial chegar
     if tipo == TipoPacote.INICIAL and estados_ativos:
-        await _encerrar_corridas_ativas(session, sessao_hardware_id)
+        await _abortar_corridas_ativas(session, sessao_hardware_id)
 
     # Recupera ou inicializa o estado em memória
     if sessao_hardware_id not in estados_ativos:
@@ -166,14 +166,14 @@ async def receber_pacote_telemetria(
     return {"message": "Pacote processado com sucesso", "estado": estado_dict}
 
 
-async def _encerrar_corridas_ativas(
+async def _abortar_corridas_ativas(
     session: Session,
     novo_sessao_id: int,
 ) -> None:
-    """Encerra corridas ativas quando uma nova sessão é iniciada.
+    """Aborta corridas ativas quando uma nova sessão é iniciada.
 
     Garante que apenas uma corrida esteja ativa por vez,
-    encerrando as anteriores com status FALHA no banco de dados.
+    abortando as anteriores com status ABORTADA no banco de dados.
     """
     ids_para_remover = [
         sid for sid in estados_ativos

--- a/src/backend/tests/test_websocket.py
+++ b/src/backend/tests/test_websocket.py
@@ -4,7 +4,8 @@ from fastapi.testclient import TestClient
 def test_websocket_connection(client:TestClient):
     with client.websocket_connect("/api/telemetria/ws") as websocket:
         message = websocket.receive_json()
-        assert message == {"message": "connected"}
+        assert message["type"] == "HANDSHAKE"
+        assert message["data"]["status"] == "connected"
 
 def test_telemetry_post_endpoint(client:TestClient):
     response = client.post("/api/telemetria/pacote", json={
@@ -22,7 +23,8 @@ def test_telemetry_post_endpoint(client:TestClient):
 def test_websocket_message_delivery(client:TestClient):
     with client.websocket_connect("/api/telemetria/ws") as websocket:
         msg_conexao = websocket.receive_json()
-        assert msg_conexao == {"message": "connected"}
+        assert msg_conexao["type"] == "HANDSHAKE"
+        assert msg_conexao["data"]["status"] == "connected"
 
         # Enviamos um pacote de telemetria
         response = client.post("/api/telemetria/pacote", json={

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -115,6 +115,15 @@ export function useTelemetria(): UseTelemetriaReturn {
           return;
         }
 
+        if (parsed.type === "SESSAO_ENCERRADA") {
+          console.log("[useTelemetria] Sessão anterior encerrada:", parsed.data);
+          setIndicadores(ESTADO_INICIAL);
+          setConfigSessao(CONFIG_SESSAO_INICIAL);
+          setStatusConexao("waiting");
+          setMensagemStatusConexao(null);
+          return;
+        }
+
         if (parsed.type === "SESSAO_INICIADA" && parsed.data) {
           const { dimensao, tentativa, ...indicadoresData } = parsed.data;
           setIndicadores(indicadoresData as IndicadoresDesempenho);


### PR DESCRIPTION

## Descrição
Este PR implementa melhorias na comunicação WebSocket e no gerenciamento de ciclo de vida das corridas para a **[US-20]: Estabelecer comunicação com o micromouse #95**. 

Focamos em garantir o cumprimento semântico do **CA-20-01** (handshake de conexão) e do **CA-20-03** (recuperação de conexão e limpeza de sessões anteriores), impedindo que corridas antigas ou órfãs fiquem ativas em memória e no banco de dados quando uma nova sessão for iniciada pelo robô.

---

## Mudanças Realizadas

### Backend (`src/backend`)

1. **Mensagem de Handshake Estruturada (CA-20-01)**:
   - No endpoint do WebSocket (`/api/telemetria/ws`), a resposta inicial genérica `{"message": "connected"}` foi substituída por um evento padronizado do tipo `HANDSHAKE`.
   - Payload enviado no momento da conexão:
     ```json
     {
       "type": "HANDSHAKE",
       "data": {
         "status": "connected",
         "server_time": "2026-05-27T...",
         "version": "0.1.0"
       }
     }
     ```

2. **Garantia de Corrida Única Ativa & Abortagem Automática (CA-20-03)**:
   - Adicionada a função assíncrona `_abortar_corridas_ativas(session, novo_sessao_id)` em `app/routers/telemetria.py`.
   - Sempre que um pacote do tipo `INICIAL` chega para um novo `id_corrida`, o backend verifica se há estados de corridas anteriores ainda ativos na memória (`estados_ativos`).
   - Se houver, a função:
     - Altera o status da corrida antiga no banco de dados para `StatusCorrida.ABORTADA` (enum correto cadastrado no Postgres) e registra a data e hora de fim.
     - Remove o estado anterior da memória.
     - Remove o monitoramento do `connection_monitor` para evitar falsos offline/timeouts de corridas antigas.
     - Dispara o evento WebSocket `SESSAO_ENCERRADA` para notificar todos os clientes conectados.

###  Frontend (`src/frontend`)

1. **Tratamento de `SESSAO_ENCERRADA`**:
   - Atualizado o hook `useTelemetria.ts` para processar a mensagem do tipo `SESSAO_ENCERRADA`.
   - Limpa o estado global de `indicadores` e `configSessao` para os valores padrões (`ESTADO_INICIAL` e `CONFIG_SESSAO_INICIAL`), além de redefinir o status de conexão para `waiting`.
   - Isso garante que a UI seja reiniciada de forma limpa e imediata, pronta para exibir as novas métricas que chegarão na sequência pelo robô.

### Testes de Integração

1. **Atualização dos Testes do WebSocket**:
   - As asserções em `tests/test_websocket.py` (`test_websocket_connection` e `test_websocket_message_delivery`) foram ajustadas para validar o novo formato de handshake baseado em `type` e `data.status`.

---

## Como Testar

1. **Executar a suíte de testes do Backend**:
   Certifique-se de que o ambiente virtual está ativo e o banco de dados de teste está de pé:
   ```bash
   cd src/backend
   pytest -s
   ```
   *Resultado esperado:* Todos os 82 testes devem passar com sucesso (`82 passed`).

2. **Simulação Manual de Nova Sessão**:
   - Inicie o backend e o frontend da aplicação.
   - Envie um pacote `INICIAL` para a corrida `X` via HTTP POST. A interface deve transitar de "Aguardando" para "Sessão Iniciada".
   - Envie um pacote `INICIAL` para a corrida `Y`. O console do frontend deve registrar a recepção do evento `SESSAO_ENCERRADA`, redefinindo os dados na tela antes de abrir a nova sessão para o robô `Y`.

---

## Status dos Testes
- **Testes Backend**: 82 passados, 0 falhas. 
- **Compilação TypeScript Frontend**: Passando sem erros. 