### PR TITLE
feat:  Implementa e ajusta persistência dos dados da corrida

### DIFF
--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -1,8 +1,9 @@
 from datetime import datetime, UTC
 from typing import Dict, Any
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, HTTPException
-from sqlmodel import Session
 import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, HTTPException
+from sqlmodel import Session, select
 
 from ..database import get_session
 from ..services.telemetria import (
@@ -14,9 +15,11 @@ from ..services.telemetria import (
 from ..schemas.telemetria import IndicadoresDesempenho, TipoPacote
 from ..services.websocket_manager import manager
 from ..services.connection_monitor import connection_monitor
+from ..models.celula import Celula
 from ..models.corrida import Corrida
 from ..models.evento import Evento
 from ..models.labirinto import Labirinto
+from ..models.percurso import Percurso
 from ..models.enums import StatusCorrida, TipoLabirinto
 
 logger = logging.getLogger(__name__)
@@ -164,14 +167,32 @@ async def receber_pacote_telemetria(
         session.refresh(corrida)
         commit_realizado = True
 
+    # Se for pacote de movimentação, persistir step no percurso
+    if tipo == TipoPacote.MOVIMENTACAO and novo_estado.id_corrida_banco is not None:
+        x = pacote.get("x")
+        y = pacote.get("y")
+        if x is not None and y is not None:
+            _persistir_passo_percurso(
+                session,
+                id_corrida=novo_estado.id_corrida_banco,
+                x=float(x),
+                y=float(y),
+            )
+            if not commit_realizado:
+                _persistir_novos_alertas(session, estado_atual, novo_estado)
+                session.commit()
+                commit_realizado = True
+
     # Se for pacote final, atualizar o banco de dados
     if tipo == TipoPacote.FINAL and novo_estado.id_corrida_banco is not None:
         corrida = session.get(Corrida, novo_estado.id_corrida_banco)
         if corrida:
-            corrida.status_corrida = StatusCorrida.CONCLUIDA if novo_estado.sucesso else StatusCorrida.FALHA
+            # O pacote FINAL sempre conclui a corrida; desafio_cumprido diferencia o resultado
+            corrida.status_corrida = StatusCorrida.CONCLUIDA
             corrida.data_hora_fim = datetime.now(UTC)
             corrida.bateria_final = novo_estado.bateria_final
             corrida.velocidade_media = novo_estado.velocidade_media
+            corrida.tempo_total = novo_estado.tempo_final_ms
             corrida.desafio_cumprido = novo_estado.sucesso
             session.add(corrida)
             _persistir_novos_alertas(session, estado_atual, novo_estado)
@@ -302,3 +323,46 @@ def _persistir_novos_alertas(
         )
 
     return True
+
+
+def _persistir_passo_percurso(
+    session: Session,
+    id_corrida: int,
+    x: float,
+    y: float,
+) -> None:
+    """Persiste um passo do percurso para a posição (x, y) do Micromouse.
+
+    Reutiliza a Célula existente para aquela coordenada+labirinto, ou cria
+    uma nova (com paredes nulas) se for a primeira vez que o robô visita a posição.
+    """
+    # Recupera o id_labirinto a partir da corrida
+    corrida = session.get(Corrida, id_corrida)
+    if corrida is None:
+        logger.warning("_persistir_passo_percurso: corrida %d não encontrada.", id_corrida)
+        return
+
+    # Encontra ou cria a Célula correspondente à posição
+    celula = session.exec(
+        select(Celula)
+        .where(Celula.coordenada_x == int(x))
+        .where(Celula.coordenada_y == int(y))
+        .where(Celula.id_labirinto == corrida.id_labirinto)
+    ).first()
+
+    if celula is None:
+        celula = Celula(
+            coordenada_x=int(x),
+            coordenada_y=int(y),
+            id_labirinto=corrida.id_labirinto,
+        )
+        session.add(celula)
+        session.flush()  # Garante id_celula antes de criar Percurso
+
+    # Registra passagem pelo passo do percurso
+    passo = Percurso(
+        id_celula=celula.id_celula,
+        id_corrida=id_corrida,
+        data_hora_passagem=datetime.now(UTC),
+    )
+    session.add(passo)

--- a/src/backend/tests/test_persistencia.py
+++ b/src/backend/tests/test_persistencia.py
@@ -1,0 +1,331 @@
+"""Testes de persistência — TASK-SW-16A.
+
+Cobre os critérios de aceite:
+  ✓ Modelo de banco para dados da corrida.
+  ✓ Salva dados consolidados ao receber evento de encerramento.
+  ✓ Registra trajeto percorrido durante a execução.
+  ✓ Registra dados de telemetria recebidos.
+  ✓ Registra tempo total da corrida.
+  ✓ Registra resultado do desafio.
+  ✓ Registra tipo/dimensão do labirinto.
+  ✓ Impede persistência com campos obrigatórios ausentes.
+"""
+from datetime import datetime, UTC
+
+import pytest
+from sqlmodel import Session, select
+from fastapi.testclient import TestClient
+
+from app.models.corrida import Corrida
+from app.models.labirinto import Labirinto
+from app.models.percurso import Percurso
+from app.models.celula import Celula
+from app.models.evento import Evento
+from app.models.enums import StatusCorrida, TipoLabirinto
+from app.schemas.corrida import (
+    CorridaStart,
+    CorridaSave,
+    CelulaCreate,
+    ConexaoCreate,
+    PercursoCreate,
+)
+from app.services.registro import RegistroError, iniciar_corrida, salvar_corrida
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PACOTE_INICIAL = {
+    "id_corrida": 42,
+    "timestamp_ms": 0,
+    "dimensao": 4,
+    "tentativa": 1,
+    "bateria": 100.0,
+}
+
+PACOTE_MOV_1 = {
+    "id_corrida": 42,
+    "timestamp_ms": 1000,
+    "x": 1,
+    "y": 0,
+    "w": 0,
+    "bateria": 98.0,
+}
+
+PACOTE_MOV_2 = {
+    "id_corrida": 42,
+    "timestamp_ms": 2000,
+    "x": 2,
+    "y": 0,
+    "w": 0,
+}
+
+PACOTE_FINAL = {
+    "id_corrida": 42,
+    "timestamp_ms": 5000,
+    "sucesso": True,
+    "v_med": 25.0,
+    "bateria": 85.0,
+}
+
+
+# ---------------------------------------------------------------------------
+# Testes do serviço de registro (registro.py)
+# ---------------------------------------------------------------------------
+
+
+class TestIniciarCorrida:
+    """CA: Existe uma estrutura/modelo de banco para armazenar dados da corrida."""
+
+    def test_cria_labirinto_e_corrida(self, session: Session):
+        payload = CorridaStart(
+            tipo_labirinto=TipoLabirinto.QUATRO,
+            data_hora_inicio=datetime.now(UTC),
+        )
+        corrida = iniciar_corrida(session, payload)
+
+        assert corrida.id_corrida is not None
+        assert corrida.id_labirinto is not None
+        assert corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
+
+    def test_labirinto_tem_tipo_correto_4x4(self, session: Session):
+        payload = CorridaStart(
+            tipo_labirinto=TipoLabirinto.QUATRO,
+            data_hora_inicio=datetime.now(UTC),
+        )
+        corrida = iniciar_corrida(session, payload)
+        labirinto = session.get(Labirinto, corrida.id_labirinto)
+
+        assert labirinto is not None
+        assert labirinto.tipo_labirinto == TipoLabirinto.QUATRO
+
+    def test_labirinto_tem_tipo_correto_16x16(self, session: Session):
+        payload = CorridaStart(
+            tipo_labirinto=TipoLabirinto.DEZESSEIS,
+            data_hora_inicio=datetime.now(UTC),
+        )
+        corrida = iniciar_corrida(session, payload)
+        labirinto = session.get(Labirinto, corrida.id_labirinto)
+
+        assert labirinto.tipo_labirinto == TipoLabirinto.DEZESSEIS
+
+    def test_data_hora_inicio_e_salva(self, session: Session):
+        agora = datetime.now(UTC)
+        payload = CorridaStart(
+            tipo_labirinto=TipoLabirinto.OITO,
+            data_hora_inicio=agora,
+        )
+        corrida = iniciar_corrida(session, payload)
+        assert corrida.data_hora_inicio is not None
+
+
+class TestSalvarCorrida:
+    """CA: Sistema salva dados consolidados ao receber evento de encerramento."""
+
+    def _base(self, session: Session) -> Corrida:
+        return iniciar_corrida(
+            session,
+            CorridaStart(
+                tipo_labirinto=TipoLabirinto.QUATRO,
+                data_hora_inicio=datetime.now(UTC),
+            ),
+        )
+
+    def test_salva_campos_basicos(self, session: Session):
+        corrida = self._base(session)
+        payload = CorridaSave(
+            tempo_total=5000,
+            velocidade_media=30.0,
+            velocidade_maxima_percurso=55.0,
+            status_corrida=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=True,
+            data_hora_fim=datetime.now(UTC),
+        )
+        resultado = salvar_corrida(session, corrida.id_corrida, payload)
+
+        assert resultado.tempo_total == 5000
+        assert resultado.velocidade_media == 30.0
+        assert resultado.status_corrida == StatusCorrida.CONCLUIDA
+        assert resultado.desafio_cumprido is True
+
+    def test_salva_resultado_falha(self, session: Session):
+        """CA: Registra resultado do desafio (sucesso/falha)."""
+        corrida = self._base(session)
+        payload = CorridaSave(
+            tempo_total=3000,
+            status_corrida=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=False,
+        )
+        resultado = salvar_corrida(session, corrida.id_corrida, payload)
+
+        assert resultado.desafio_cumprido is False
+        assert resultado.status_corrida == StatusCorrida.CONCLUIDA
+
+    def test_salva_percurso_via_celulas(self, session: Session):
+        """CA: Registra trajeto percorrido."""
+        corrida = self._base(session)
+        celulas = [
+            CelulaCreate(coordenada_x=0, coordenada_y=0,
+                         parede_norte=False, parede_sul=True,
+                         parede_leste=False, parede_oeste=True),
+            CelulaCreate(coordenada_x=1, coordenada_y=0,
+                         parede_norte=False, parede_sul=True,
+                         parede_leste=False, parede_oeste=False),
+        ]
+        percurso = [
+            PercursoCreate(indice_celula=0, data_hora_passagem=datetime.now(UTC)),
+            PercursoCreate(indice_celula=1, data_hora_passagem=datetime.now(UTC)),
+        ]
+        payload = CorridaSave(
+            tempo_total=2000,
+            status_corrida=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=True,
+            celulas=celulas,
+            percurso=percurso,
+        )
+        salvar_corrida(session, corrida.id_corrida, payload)
+
+        passos = session.exec(
+            select(Percurso).where(Percurso.id_corrida == corrida.id_corrida)
+        ).all()
+        assert len(passos) == 2
+
+    def test_tempo_total_negativo_levanta_registro_error(self, session: Session):
+        """CA: Impede persistência quando campos obrigatórios estiverem inválidos."""
+        corrida = self._base(session)
+        payload = CorridaSave(
+            tempo_total=-1,
+            status_corrida=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=False,
+        )
+        with pytest.raises(RegistroError):
+            salvar_corrida(session, corrida.id_corrida, payload)
+
+    def test_corrida_inexistente_levanta_registro_error(self, session: Session):
+        """CA: Impede persistência quando corrida não existe."""
+        payload = CorridaSave(
+            tempo_total=1000,
+            status_corrida=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=True,
+        )
+        with pytest.raises(RegistroError):
+            salvar_corrida(session, 999999, payload)
+
+
+# ---------------------------------------------------------------------------
+# Testes de persistência via fluxo de telemetria (endpoint HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenciaFluxoTelemetria:
+    """Testa persistência end-to-end via endpoint POST /api/telemetria/pacote."""
+
+    def test_pacote_inicial_cria_corrida_no_banco(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Existe estrutura de banco / registra tipo do labirinto."""
+        resp = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        assert resp.status_code == 201
+
+        id_corrida_banco = resp.json()["estado"]["id_corrida_banco"]
+        assert id_corrida_banco is not None
+
+        corrida = session.get(Corrida, id_corrida_banco)
+        assert corrida is not None
+        assert corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
+        assert corrida.sessao_hardware_id == 42
+
+        labirinto = session.get(Labirinto, corrida.id_labirinto)
+        assert labirinto is not None
+        assert labirinto.tipo_labirinto == TipoLabirinto.QUATRO
+
+    def test_pacote_movimentacao_registra_percurso(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Sistema registra trajeto percorrido durante a execução."""
+        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+
+        client.post("/api/telemetria/pacote", json=PACOTE_MOV_1)
+        client.post("/api/telemetria/pacote", json=PACOTE_MOV_2)
+
+        passos = session.exec(
+            select(Percurso).where(Percurso.id_corrida == id_corrida_banco)
+        ).all()
+        assert len(passos) == 2
+
+    def test_percurso_reutiliza_celula_existente(
+        self, client: TestClient, session: Session
+    ):
+        """Robô que revisita posição não deve duplicar Célula, só Percurso."""
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        # Dois pacotes na mesma posição (x=1, y=0)
+        client.post("/api/telemetria/pacote", json=PACOTE_MOV_1)
+        client.post("/api/telemetria/pacote", json={**PACOTE_MOV_1, "timestamp_ms": 3000})
+
+        celulas = session.exec(
+            select(Celula).where(Celula.coordenada_x == 1).where(Celula.coordenada_y == 0)
+        ).all()
+        # Apenas uma Célula para a posição (1, 0)
+        assert len(celulas) == 1
+
+    def test_pacote_final_salva_tempo_total(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Sistema registra tempo total da corrida."""
+        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+
+        client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
+
+        corrida = session.get(Corrida, id_corrida_banco)
+        assert corrida.tempo_total == PACOTE_FINAL["timestamp_ms"]
+
+    def test_pacote_final_salva_resultado_desafio(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Sistema registra resultado do desafio (sucesso/falha)."""
+        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+
+        client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
+
+        corrida = session.get(Corrida, id_corrida_banco)
+        assert corrida.desafio_cumprido is True
+        assert corrida.status_corrida == StatusCorrida.CONCLUIDA
+
+    def test_pacote_final_falha_salva_status_correto(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Resultado de falha registrado corretamente via desafio_cumprido."""
+        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+
+        pacote_falha = {**PACOTE_FINAL, "sucesso": False}
+        client.post("/api/telemetria/pacote", json=pacote_falha)
+
+        corrida = session.get(Corrida, id_corrida_banco)
+        assert corrida.desafio_cumprido is False
+        # Status é sempre CONCLUIDA quando o pacote final é recebido
+        assert corrida.status_corrida == StatusCorrida.CONCLUIDA
+
+    def test_pacote_invalido_nao_persiste(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Impede persistência quando campos obrigatórios estão ausentes."""
+        # Pacote sem id_corrida e sem campos reconhecíveis
+        resp = client.post("/api/telemetria/pacote", json={"foo": "bar"})
+        assert resp.status_code == 422
+
+    def test_corrida_conclui_com_velocidade_media_do_firmware(
+        self, client: TestClient, session: Session
+    ):
+        """CA: Sistema registra dados de telemetria — velocidade média (do pacote final)."""
+        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+
+        client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
+
+        corrida = session.get(Corrida, id_corrida_banco)
+        assert corrida.velocidade_media == PACOTE_FINAL["v_med"]


### PR DESCRIPTION
# [Backend] Implementar persistência dos dados da corrida

## Contexto

Implementa a persistência completa dos dados de uma corrida ao longo do fluxo de telemetria.

Anteriormente, ao receber o pacote final da ESP32, o backend salvava apenas `bateria_final`, `velocidade_media` e `desafio_cumprido`. Campos como `tempo_total` e o trajeto percorrido eram ignorados. Esta PR completa a persistência, garantindo que todos os dados relevantes da corrida sejam armazenados no banco ao final da execução.

---

## O que foi feito

### Persistência do trajeto percorrido (novo)

Implementada a função `_persistir_passo_percurso()` no router de telemetria. A cada pacote de **movimentação** válido recebido:

1. O backend busca a `Célula` com aquelas coordenadas `(x, y)` no labirinto da corrida atual.
2. Se a célula ainda não existir, ela é criada (com paredes nulas — para suportar mapeamento futuro).
3. Um registro `Percurso` é inserido, vinculando o instante da passagem à célula e à corrida.

Células são **reutilizadas** entre visitas: se o robô revisita uma posição, cria-se um novo `Percurso` mas não uma nova `Célula`.

### Persistência completa ao encerramento (corrigido)

Ao receber o pacote **final**, agora são salvos:

| Campo | Origem |
|---|---|
| `tempo_total` | `timestamp_ms` do pacote final |
| `velocidade_media` | `v_med` do pacote final (enviado pelo firmware) |
| `bateria_final` | `bateria` do pacote final |
| `desafio_cumprido` | `sucesso` do pacote final |
| `data_hora_fim` | `datetime.now(UTC)` |
| `status_corrida` | `CONCLUIDA` (o resultado é diferenciado por `desafio_cumprido`) |

### Correção de bug: `StatusCorrida.FALHA`

O código anterior tentava atribuir `StatusCorrida.FALHA`, que **não existe no enum**. Corrigido para sempre usar `CONCLUIDA` ao receber o pacote final — o campo `desafio_cumprido` já diferencia sucesso de insucesso. `ABORTADA` continua sendo usado apenas para corridas interrompidas por perda de conexão.

### Novos testes (`tests/test_persistencia.py`)

17 testes cobrindo todos os critérios de aceite da task:

| Classe | O que testa |
|---|---|
| `TestIniciarCorrida` | Criação de `Labirinto` + `Corrida`, tipos de labirinto, data de início |
| `TestSalvarCorrida` | Save via `registro.py`: campos básicos, resultado de falha, percurso via células, validações obrigatórias |
| `TestPersistenciaFluxoTelemetria` | Fluxo end-to-end via endpoint: criação no banco no pacote inicial, percurso salvo no MOVIMENTACAO, reutilização de célula, tempo total, resultado, pacote inválido rejeitado, velocidade média |

---

## Arquivos alterados

| Arquivo | Tipo |
|---|---|
| `app/routers/telemetria.py` | 🔧 Modificado |
| `app/schemas/telemetria.py` | 🔧 Modificado |
| `app/services/telemetria.py` | 🔧 Modificado |
| `tests/test_persistencia.py` | ✨ Novo |

---

## Critérios de Aceite

| CA | Status |
|---|---|
| Existe estrutura/modelo de banco para dados da corrida | ✅ Já existia |
| Sistema salva dados consolidados ao encerrar corrida | ✅ Implementado |
| Sistema registra o trajeto percorrido | ✅ Implementado |
| Sistema registra dados de telemetria recebidos | ✅ Implementado |
| Sistema registra tempo total da corrida | ✅ Implementado |
| Sistema registra resultado do desafio (sucesso/falha) | ✅ Implementado |
| Sistema registra tipo/dimensão do labirinto | ✅ Já existia |
| Impede persistência com campos obrigatórios ausentes | ✅ Validação Pydantic + `RegistroError` |
| Modelagem permite futuras adaptações (mapeamento, fast run) | ✅ Células com paredes nulas permitem expansão |

---

## Resultado dos testes

```
109 passed in 6.50s
```

---

## Como testar manualmente

### 1. Subir o ambiente

```bash
docker compose down --remove-orphans
docker compose up --build --force-recreate -d
docker compose logs api --tail=20  # aguardar "Application startup complete"
```

---

### 2. Rodar os testes automatizados

```bash
docker compose exec api pytest -v
```

---

### 3. Simular um ciclo completo via curl

#### Passo 1 — Pacote inicial (cria corrida + labirinto no banco)

```bash
curl -s -X POST http://localhost:8000/api/telemetria/pacote \
  -H "Content-Type: application/json" \
  -d '{"id_corrida": 1, "timestamp_ms": 0, "dimensao": 16, "tentativa": 1, "bateria": 100.0}' \
  | python3 -m json.tool
```

Resposta:
```json
{
    "message": "Pacote processado com sucesso",
    "estado": {
        "id_corrida_banco": 1,
        "sessao_hardware_id": 1,
        "bateria_inicial": 100.0,
        "bateria_atual": 100.0,
        "bateria_final": null,
        "velocidade_media": null,
        "tempo_decorrido_ms": 0,
        "tempo_final_ms": null,
        "status_corrida": "em_andamento",
        "sucesso": null,
        "ultimo_timestamp_ms": 0,
        "alerta_bateria_critica": false,
        "alerta_possivel_parada_inesperada": false,
        "alerta_dado_invalido": false,
        "log_alertas": []
    }
}
```

#### Passo 2 — Pacote de movimentação (persiste passo no trajeto)

```bash
curl -s -X POST http://localhost:8000/api/telemetria/pacote \
  -H "Content-Type: application/json" \
  -d '{"id_corrida": 1, "timestamp_ms": 3000, "x": 1, "y": 0, "w": 0}' \
  | python3 -m json.tool
```

Resposta:
```json
{
    "message": "Pacote processado com sucesso",
    "estado": {
        "id_corrida_banco": 1,
        "sessao_hardware_id": 1,
        "bateria_inicial": 100.0,
        "bateria_atual": 100.0,
        "bateria_final": null,
        "velocidade_media": null,
        "tempo_decorrido_ms": 3000,
        "tempo_final_ms": null,
        "status_corrida": "em_andamento",
        "sucesso": null,
        "ultimo_timestamp_ms": 3000,
        "alerta_bateria_critica": false,
        "alerta_possivel_parada_inesperada": false,
        "alerta_dado_invalido": false,
        "log_alertas": []
    }
}
```

#### Passo 3 — Pacote final (persiste dados consolidados no banco)

```bash
curl -s -X POST http://localhost:8000/api/telemetria/pacote \
  -H "Content-Type: application/json" \
  -d '{"id_corrida": 1, "timestamp_ms": 10000, "sucesso": true, "v_med": 22.5, "bateria": 88.0}' \
  | python3 -m json.tool
```

Resposta:
```json
{
    "message": "Pacote processado com sucesso",
    "estado": {
        "id_corrida_banco": 1,
        "sessao_hardware_id": 1,
        "bateria_inicial": 100.0,
        "bateria_atual": 88.0,
        "bateria_final": 88.0,
        "velocidade_media": 22.5,
        "tempo_decorrido_ms": 10000,
        "tempo_final_ms": 10000,
        "status_corrida": "concluida",
        "sucesso": true,
        "ultimo_timestamp_ms": 10000,
        "alerta_bateria_critica": false,
        "alerta_possivel_parada_inesperada": false,
        "alerta_dado_invalido": false,
        "log_alertas": []
    }
}
```

#### Passo 4 — Consultar a corrida persistida no banco

```bash
curl -s http://localhost:8000/api/corridas/1 | python3 -m json.tool
```

Resposta (evidencia todos os campos salvos + percurso):
```json
{
    "id_corrida": 1,
    "tempo_total": 10000,
    "tensao_media": null,
    "corrente_media": null,
    "velocidade_maxima_percurso": null,
    "velocidade_media": 22.5,
    "status_corrida": "CONCLUIDA",
    "desafio_cumprido": true,
    "data_hora_inicio": "2026-05-30T21:55:56.568790Z",
    "data_hora_fim": "2026-05-30T21:55:56.617385Z",
    "tipo_labirinto": "16X16",
    "percurso": [
        {
            "id_percurso": 1,
            "id_celula": 1,
            "data_hora_passagem": "2026-05-30T21:55:56.593510Z"
        }
    ]
}
```

> **O que validar:** `tempo_total: 10000`, `velocidade_media: 22.5`, `desafio_cumprido: true`, `status_corrida: "CONCLUIDA"` e `percurso` com 1 entrada — confirmando que o trajeto foi salvo no pacote de movimentação.

---

<img width="1128" height="533" alt="image" src="https://github.com/user-attachments/assets/097567ad-9485-414a-8dd1-63fb035fd6fa" />

<img width="644" height="917" alt="image" src="https://github.com/user-attachments/assets/9cc11880-1be1-45a3-8538-f1ba99d17adf" />

<img width="644" height="553" alt="image" src="https://github.com/user-attachments/assets/7d3c5287-7f1f-41bc-bf75-546d57b7b0bf" />


## Closes

Closes #356
