### PR TITLE
(US-17)  Implementação do Endpoint de Melhor Resultado por Tipo de Labirinto 

### DIFF
--- a/src/backend/app/routers/labirinto.py
+++ b/src/backend/app/routers/labirinto.py
@@ -5,12 +5,15 @@ from sqlmodel import Session, select
 
 from ..database import get_session
 from ..models.celula import Celula
-from ..models.enums import TipoLabirinto
+from ..models.corrida import Corrida
+from ..models.enums import StatusCorrida, TipoLabirinto
 from ..models.labirinto import Labirinto
 from ..schemas.labirinto import (
     CelulaResponse,
     LabirintoResponse,
     LabirintoResumoResponse,
+    MelhorResultadoResponse,
+    RecordeLabirintoResponse,
 )
 
 router = APIRouter(prefix="/api/labirintos", tags=["labirintos"])
@@ -47,6 +50,48 @@ def listar_labirintos(
         )
         for lab in labirintos
     ]
+
+
+
+@router.get(
+    "/melhor-resultado",
+    response_model=MelhorResultadoResponse,
+    summary="Melhor resultado (recorde) por tipo de labirinto",
+)
+def obter_melhor_resultado(
+    tipo: TipoLabirinto = Query(
+        description="Tipo de labirinto (4X4, 8X8, 16X16).",
+    ),
+    session: Session = Depends(get_session),
+) -> MelhorResultadoResponse:
+    """Retorna a corrida com o menor tempo de conclusão dentre todos
+    os labirintos do tipo informado, filtrando apenas sessões concluídas
+    com desafio cumprido.
+    """
+    # Buscar melhor resultado entre todos os labirintos do tipo
+    statement = (
+        select(Corrida)
+        .join(Labirinto, Corrida.id_labirinto == Labirinto.id_labirinto)
+        .where(Labirinto.tipo_labirinto == tipo)
+        .where(Corrida.status_corrida == StatusCorrida.CONCLUIDA)
+        .where(Corrida.desafio_cumprido == True)  # noqa: E712
+        .where(Corrida.tempo_total.isnot(None))  # type: ignore[union-attr]
+        .order_by(Corrida.tempo_total.asc())  # type: ignore[union-attr]
+        .limit(1)
+    )
+    corrida = session.exec(statement).first()
+
+    if corrida is None:
+        return MelhorResultadoResponse(melhor_resultado=None)
+
+    return MelhorResultadoResponse(
+        melhor_resultado=RecordeLabirintoResponse(
+            id_corrida=corrida.id_corrida,  # type: ignore[arg-type]
+            tempo_total=corrida.tempo_total,  # type: ignore[arg-type]
+            data_hora_fim=corrida.data_hora_fim,  # type: ignore[arg-type]
+            tipo_labirinto=tipo,
+        )
+    )
 
 
 @router.get(

--- a/src/backend/app/schemas/labirinto.py
+++ b/src/backend/app/schemas/labirinto.py
@@ -1,5 +1,7 @@
 """Schemas Pydantic para Labirinto e Célula."""
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 from ..models.enums import TipoLabirinto
@@ -30,3 +32,24 @@ class LabirintoResumoResponse(BaseModel):
 
     id_labirinto: int
     tipo_labirinto: TipoLabirinto
+
+
+class RecordeLabirintoResponse(BaseModel):
+    """Dados do recorde (melhor resultado) de um labirinto."""
+
+    id_corrida: int
+    tempo_total: int
+    data_hora_fim: datetime
+    tipo_labirinto: TipoLabirinto
+
+    model_config = {"from_attributes": True}
+
+
+class MelhorResultadoResponse(BaseModel):
+    """Wrapper da resposta de melhor resultado.
+
+    Retorna ``melhor_resultado: null`` quando nenhuma corrida
+    atende aos filtros.
+    """
+
+    melhor_resultado: RecordeLabirintoResponse | None = None

--- a/src/backend/tests/test_melhor_resultado.py
+++ b/src/backend/tests/test_melhor_resultado.py
@@ -1,0 +1,199 @@
+"""Testes do endpoint GET /api/labirintos/melhor-resultado?tipo=<TIPO>.
+
+Cobertura:
+  ✓ Tipo com múltiplas corridas concluídas → retorna a de menor tempo_total
+  ✓ Tipo sem nenhuma corrida com desafio_cumprido=True → retorna null
+  ✓ Corrida com status_corrida = ABORTADA não aparece no resultado
+  ✓ Filtro por tipo (4X4, 8X8, 16X16) isola corretamente
+"""
+
+from datetime import datetime, UTC
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models.corrida import Corrida
+from app.models.enums import StatusCorrida, TipoLabirinto
+from app.models.labirinto import Labirinto
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _criar_labirinto(session: Session, tipo: TipoLabirinto) -> Labirinto:
+    """Cria e persiste um labirinto de teste."""
+    lab = Labirinto(tipo_labirinto=tipo)
+    session.add(lab)
+    session.commit()
+    session.refresh(lab)
+    return lab
+
+
+def _criar_corrida(
+    session: Session,
+    id_labirinto: int,
+    *,
+    tempo_total: int | None = None,
+    status: StatusCorrida = StatusCorrida.CONCLUIDA,
+    desafio_cumprido: bool = True,
+    data_hora_fim: datetime | None = None,
+) -> Corrida:
+    """Cria e persiste uma corrida de teste."""
+    corrida = Corrida(
+        id_labirinto=id_labirinto,
+        tempo_total=tempo_total,
+        status_corrida=status,
+        desafio_cumprido=desafio_cumprido,
+        data_hora_inicio=datetime.now(UTC),
+        data_hora_fim=data_hora_fim or datetime.now(UTC),
+    )
+    session.add(corrida)
+    session.commit()
+    session.refresh(corrida)
+    return corrida
+
+
+# ---------------------------------------------------------------------------
+# Testes
+# ---------------------------------------------------------------------------
+
+
+class TestMelhorResultadoEndpoint:
+    """Testa GET /api/labirintos/melhor-resultado?tipo=<TIPO>."""
+
+    # CA-17-01: múltiplas corridas → retorna a de menor tempo_total
+    def test_retorna_corrida_de_menor_tempo(
+        self, client: TestClient, session: Session
+    ):
+        """Dado múltiplas corridas concluídas com desafio cumprido (em labirintos
+        distintos do mesmo tipo, como ocorre na prática), deve retornar a de
+        menor tempo_total."""
+        lab1 = _criar_labirinto(session, TipoLabirinto.QUATRO)
+        lab2 = _criar_labirinto(session, TipoLabirinto.QUATRO)
+        lab3 = _criar_labirinto(session, TipoLabirinto.QUATRO)
+
+        _criar_corrida(session, lab1.id_labirinto, tempo_total=5000)
+        c_melhor = _criar_corrida(session, lab2.id_labirinto, tempo_total=3000)
+        _criar_corrida(session, lab3.id_labirinto, tempo_total=7000)
+
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "4X4"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["melhor_resultado"] is not None
+        assert data["melhor_resultado"]["id_corrida"] == c_melhor.id_corrida
+        assert data["melhor_resultado"]["tempo_total"] == 3000
+
+    # CA-17-03: sem corridas com desafio cumprido → retorna null
+    def test_retorna_null_sem_desafio_cumprido(
+        self, client: TestClient, session: Session
+    ):
+        """Dado nenhuma corrida com desafio_cumprido=True para o tipo,
+        deve retornar melhor_resultado como null."""
+        lab = _criar_labirinto(session, TipoLabirinto.OITO)
+
+        _criar_corrida(
+            session, lab.id_labirinto,
+            tempo_total=4000,
+            desafio_cumprido=False,
+        )
+
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "8X8"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["melhor_resultado"] is None
+
+    # Corrida ABORTADA não aparece
+    def test_corrida_abortada_nao_aparece(
+        self, client: TestClient, session: Session
+    ):
+        """Corrida com status ABORTADA não deve ser considerada para o recorde."""
+        lab1 = _criar_labirinto(session, TipoLabirinto.DEZESSEIS)
+        lab2 = _criar_labirinto(session, TipoLabirinto.DEZESSEIS)
+
+        # Corrida abortada com tempo baixo — não deveria aparecer
+        _criar_corrida(
+            session, lab1.id_labirinto,
+            tempo_total=1000,
+            status=StatusCorrida.ABORTADA,
+            desafio_cumprido=True,
+        )
+        # Corrida concluída com tempo maior
+        c_valida = _criar_corrida(
+            session, lab2.id_labirinto,
+            tempo_total=5000,
+            status=StatusCorrida.CONCLUIDA,
+            desafio_cumprido=True,
+        )
+
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "16X16"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["melhor_resultado"] is not None
+        assert data["melhor_resultado"]["id_corrida"] == c_valida.id_corrida
+        assert data["melhor_resultado"]["tempo_total"] == 5000
+
+    # Filtro por tipo isola corretamente
+    def test_filtro_por_tipo_isola_resultados(
+        self, client: TestClient, session: Session
+    ):
+        """Corridas em tipos diferentes não se misturam."""
+        lab_4x4 = _criar_labirinto(session, TipoLabirinto.QUATRO)
+        lab_8x8 = _criar_labirinto(session, TipoLabirinto.OITO)
+
+        c_4x4 = _criar_corrida(session, lab_4x4.id_labirinto, tempo_total=2000)
+        # Corrida 8x8 com tempo menor — não deve interferir no 4X4
+        _criar_corrida(session, lab_8x8.id_labirinto, tempo_total=1000)
+
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "4X4"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["melhor_resultado"]["id_corrida"] == c_4x4.id_corrida
+        assert data["melhor_resultado"]["tempo_total"] == 2000
+
+    # CA-17-04: resposta inclui id_corrida, tempo_total, data_hora_fim, tipo_labirinto
+    def test_resposta_contem_campos_rastreabilidade(
+        self, client: TestClient, session: Session
+    ):
+        """O destaque deve incluir id_corrida, tempo_total, data_hora_fim
+        e tipo_labirinto para rastreabilidade."""
+        lab = _criar_labirinto(session, TipoLabirinto.QUATRO)
+        fim = datetime(2026, 5, 31, 12, 0, 0, tzinfo=UTC)
+        _criar_corrida(
+            session, lab.id_labirinto,
+            tempo_total=4200,
+            data_hora_fim=fim,
+        )
+
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "4X4"})
+
+        assert resp.status_code == 200
+        resultado = resp.json()["melhor_resultado"]
+        assert "id_corrida" in resultado
+        assert resultado["tempo_total"] == 4200
+        assert "data_hora_fim" in resultado
+        assert resultado["tipo_labirinto"] == "4X4"
+
+    # Tipo sem nenhuma corrida → retorna null (não 404)
+    def test_tipo_sem_corridas_retorna_null(
+        self, client: TestClient, session: Session
+    ):
+        """Tipo de labirinto sem corridas associadas → melhor_resultado null."""
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "16X16"})
+
+        assert resp.status_code == 200
+        assert resp.json()["melhor_resultado"] is None
+
+    # Tipo inválido → 422
+    def test_tipo_invalido_retorna_422(
+        self, client: TestClient, session: Session
+    ):
+        """Tipo de labirinto inválido deve retornar 422."""
+        resp = client.get("/api/labirintos/melhor-resultado", params={"tipo": "INVALIDO"})
+        assert resp.status_code == 422


### PR DESCRIPTION
## 📝 Descrição
Este Pull Request implementa a funcionalidade para obter o **melhor tempo de conclusão** (recorde) entre todas as corridas realizadas no sistema, agrupado pelo tipo/tamanho de labirinto (`4X4`, `8X8`, `16X16`). 

Como a arquitetura do sistema gera um novo registro de `Labirinto` a cada nova corrida, a busca foi estruturada utilizando uma junção (`JOIN`) entre as tabelas `Corrida` e `Labirinto`, aplicando filtros estritos de status e sucesso para garantir a integridade do recorde.

---

## Alterações Realizadas

### 1. Modelagem de Schemas Pydantic (`src/backend/app/schemas/labirinto.py`)
Criados novos schemas para padronizar e tipar estritamente a resposta da API:
* **`RecordeLabirintoResponse`**: Representa os dados detalhados do recorde com campos para rastreabilidade:
  * `id_corrida: int` (Identificador da corrida recordista)
  * `tempo_total: int` (Tempo total gasto em milissegundos)
  * `data_hora_fim: datetime` (Data e hora em que o recorde foi estabelecido)
  * `tipo_labirinto: TipoLabirinto` (Filtro do tipo do labirinto: `4X4`, `8X8`, `16X16`)
* **`MelhorResultadoResponse`**: Modelo de resposta padrão do endpoint. Retorna o objeto do recorde ou `null` caso nenhum recorde tenha sido registrado ainda.

### 2. 🔌 Rota de API (`src/backend/app/routers/labirinto.py`)
Criação do endpoint **`GET /api/labirintos/melhor-resultado`**:
* Aceita o parâmetro de query obrigatório `tipo: TipoLabirinto` (validado automaticamente pelo Pydantic/FastAPI).
* Realiza uma consulta utilizando `SQLModel` que:
  * Junta (`JOIN`) as tabelas de `Corrida` e `Labirinto`.
  * Filtra pelo tipo informado (`Labirinto.tipo_labirinto == tipo`).
  * Garante que apenas corridas válidas e completas sejam selecionadas (`Corrida.status_corrida == StatusCorrida.CONCLUIDA`).
  * Garante que o objetivo principal tenha sido atendido (`Corrida.desafio_cumprido == True`).
  * Despreza tempos nulos (`Corrida.tempo_total.isnot(None)`).
  * Ordena de forma ascendente (`Corrida.tempo_total.asc()`) para retornar o **menor tempo**.
  * Limita a busca ao primeiro resultado (`limit(1)`).
* Caso nenhuma corrida atenda aos requisitos, retorna `melhor_resultado: null` com código `200 OK` para fácil integração com o frontend.

### 3. Suíte de Testes Automatizados (`src/backend/tests/test_melhor_resultado.py`)
Implementação de testes unitários e de integração robustos cobrindo todos os cenários e critérios de aceitação:
* **`test_retorna_corrida_de_menor_tempo`**: Garante que o endpoint isola o menor tempo quando múltiplas corridas válidas em labirintos distintos do mesmo tipo existem (Critério de Aceitação CA-17-01).
* **`test_retorna_null_sem_desafio_cumprido`**: Garante que o recorde é ignorado se o desafio não foi cumprido (Critério de Aceitação CA-17-03).
* **`test_corrida_abortada_nao_aparece`**: Garante que corridas marcadas com status `ABORTADA` sejam devidamente ignoradas.
* **`test_filtro_por_tipo_isola_resultados`**: Garante que os tempos de um tamanho de labirinto (ex: `8X8`) não interfiram ou poluam os recordes de outros tamanhos (ex: `4X4`).
* **`test_resposta_contem_campos_rastreabilidade`**: Valida a presença de todos os campos essenciais de rastreabilidade na resposta (`id_corrida`, `tempo_total`, `data_hora_fim` e `tipo_labirinto`) (Critério de Aceitação CA-17-04).
* **`test_tipo_sem_corridas_retorna_null`**: Garante retorno `200 OK` com payload `null` para tipos sem histórico de corrida.
* **`test_tipo_invalido_retorna_422`**: Garante validação de tipos de labirinto desconhecidos.

---

## Critérios de Aceitação Atendidos

| Critério | Descrição | Status | Validação |
|---|---|:---:|---|
| **CA-17-01** | Destacar corrida com o menor tempo total (`tempo_total`) | **Concluído** | `test_retorna_corrida_de_menor_tempo` |
| **CA-17-02** | Filtragem exclusiva pelo tipo de labirinto (`4X4`, `8X8`, `16X16`) | **Concluído** | `test_filtro_por_tipo_isola_resultados` |
| **CA-17-03** | Retornar `null` se não houver corrida com desafio cumprido | **Concluído** | `test_retorna_null_sem_desafio_cumprido` |
| **CA-17-04** | Resposta inclui id_corrida, tempo_total, data_hora_fim e tipo_labirinto | **Concluído** | `test_resposta_contem_campos_rastreabilidade` |

---

## Como Testar e Validar

1. Entre no diretório do backend do projeto:
   ```bash
   cd src/backend
   ```
2. Execute a suíte de testes específica criada para este endpoint utilizando a biblioteca `pytest`:
   ```bash
   .venv/bin/pytest tests/test_melhor_resultado.py
   ```
3. A saída esperada deve demonstrar sucesso em todos os cenários:
   ```text
   tests/test_melhor_resultado.py .......                                   [100%]
   ============================== 7 passed in 0.75s ===============================
   ```
closes #360 #363 
