### PR TITLE
refatora dados dos pacotes recebidos pelo backend

### DIFF
--- a/src/backend/alembic/versions/8f00147b0485_remover_coluna_tentativa.py
+++ b/src/backend/alembic/versions/8f00147b0485_remover_coluna_tentativa.py
@@ -1,0 +1,25 @@
+"""remover_coluna_tentativa
+
+Revision ID: 8f00147b0485
+Revises: 7e99036a0374
+Create Date: 2026-06-01 19:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '8f00147b0485'
+down_revision: Union[str, Sequence[str], None] = '7e99036a0374'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column('corrida', 'tentativa')
+
+
+def downgrade() -> None:
+    op.add_column('corrida', sa.Column('tentativa', sa.Integer(), nullable=True))

--- a/src/backend/app/models/corrida.py
+++ b/src/backend/app/models/corrida.py
@@ -31,7 +31,6 @@ class Corrida(SQLModel, table=True):
     id_labirinto:int,
     desafio_cumprido:bool,
     sessao_hardware_id:int,
-    tentativa:int,
     bateria_inicial:int,
     bateria_final:int,
     """
@@ -76,7 +75,6 @@ class Corrida(SQLModel, table=True):
         default=False
     )
     sessao_hardware_id: Optional[int] = None
-    tentativa: Optional[int] = None
     bateria_inicial: Optional[int] = None
     bateria_final: Optional[int] = None
 

--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -26,8 +26,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/telemetria", tags=["telemetria"])
 
-# Armazenamento em memória do estado das corridas ativas
+# ---------------------------------------------------------------------------
+# Estado em memória — sessão única ativa
+# ---------------------------------------------------------------------------
 estados_ativos: Dict[int, IndicadoresDesempenho] = {}
+_sessao_ativa_id: int | None = None
+_contador_sessao: int = 0
+
+
+def _gerar_sessao_id() -> int:
+    global _contador_sessao
+    _contador_sessao += 1
+    return _contador_sessao
+
+
+def _get_sessao_ativa_id() -> int | None:
+    return _sessao_ativa_id
+
+
+def _set_sessao_ativa_id(sid: int | None) -> None:
+    global _sessao_ativa_id
+    _sessao_ativa_id = sid
 
 
 @router.websocket("/ws")
@@ -74,28 +93,29 @@ async def receber_pacote_telemetria(
     """
     Endpoint HTTP para o Micromouse enviar pacotes de telemetria.
     Recebe o pacote, atualiza o estado em memória e notifica o Dashboard.
+
+    O ESP32 não envia ``id_corrida``; o backend gerencia uma sessão
+    única ativa por vez.
     """
     pacote = payload
     tipo = identificar_tipo_pacote(pacote)
 
-    # --- Registrar pacote no monitor de conexão e validar ---
-    await connection_monitor.registrar_pacote(pacote.get("id_corrida", 0))
-    
-    sessao_hardware_id = pacote.get("id_corrida")
-    tipo = identificar_tipo_pacote(pacote)
-    
-    # 2. Obtém o último timestamp se a sessão já existir (para validar regressão)
-    ultimo_ts = None
-    if isinstance(sessao_hardware_id, int) and sessao_hardware_id in estados_ativos:
-        ultimo_ts = estados_ativos[sessao_hardware_id].ultimo_timestamp_ms
+    # --- Validação inicial ---
+    sessao_id = _get_sessao_ativa_id()
 
-    # 3. BARREIRA DE VALIDAÇÃO RIGOROSA
+    # Determinar último timestamp para validar regressão
+    ultimo_ts = None
+    if sessao_id is not None and sessao_id in estados_ativos:
+        ultimo_ts = estados_ativos[sessao_id].ultimo_timestamp_ms
+    # Pacote inicial reseta o timestamp
+    if tipo == TipoPacote.INICIAL:
+        ultimo_ts = None
+
     resultado = validar_pacote(pacote, tipo, ultimo_ts)
     if not resultado.valido:
         erros_str = ", ".join(resultado.erros)
         logger.warning("Pacote REJEITADO por falha na validação: %s", erros_str)
-        
-        # Notificar o dashboard sobre o erro de validação
+
         await manager.send_json_to_all_clients({
             "type": "ERROR",
             "message": f"Dados inválidos do robô: {erros_str}"
@@ -106,34 +126,34 @@ async def receber_pacote_telemetria(
             detail={"mensagem": "Pacote descartado", "erros": resultado.erros},
         )
 
-    # 4. Gerenciamento de Sessão: Encerrar anteriores se for um novo pacote inicial
-    if tipo == TipoPacote.INICIAL and sessao_hardware_id not in estados_ativos:
-        await _abortar_corridas_ativas(session, sessao_hardware_id)
+    # --- Gerenciamento de sessão ---
+    if tipo == TipoPacote.INICIAL:
+        # Encerrar qualquer corrida ativa anterior
+        if sessao_id is not None and sessao_id in estados_ativos:
+            await _abortar_corrida_ativa(session, sessao_id)
 
-    elif tipo == TipoPacote.INICIAL and sessao_hardware_id in estados_ativos:
-        # Recebimento de pacote INICIAL com um `sessao_hardware_id` já em uso.
-        # Enviar notificação de erro ao dashboard e retornar uma exceção
-        logger.error("Pacote INICIAL rejeitado: id de sessão repetido %s", sessao_hardware_id)
-        await manager.send_json_to_all_clients({
-            "type": "ERROR",
-            "message": f"ID de sessão repetido recebido: {sessao_hardware_id}. Pacote INICIAL rejeitado."
-        })
-        raise HTTPException(
-            status_code=404,
-            detail={"mensagem": "ID de sessão repetido", "id_corrida": sessao_hardware_id},
-        )
-    # 5. Inicializa ou recupera estado
-    if sessao_hardware_id not in estados_ativos:
-        estados_ativos[sessao_hardware_id] = criar_estado_inicial()
+        # Criar nova sessão
+        sessao_id = _gerar_sessao_id()
+        _set_sessao_ativa_id(sessao_id)
+        estados_ativos[sessao_id] = criar_estado_inicial()
+        await connection_monitor.registrar_pacote(sessao_id)
+    else:
+        # Para pacotes não-iniciais, deve existir uma sessão ativa
+        if sessao_id is None or sessao_id not in estados_ativos:
+            raise HTTPException(
+                status_code=409,
+                detail={"mensagem": "Nenhuma corrida ativa. Envie um pacote inicial (tipo=0) primeiro."},
+            )
+        await connection_monitor.registrar_pacote(sessao_id)
 
-    estado_atual = estados_ativos[sessao_hardware_id]
+    estado_atual = estados_ativos[sessao_id]
 
-    # 5. Processa os indicadores puros (Cálculos de velocidade, etc)
+    # Processa os indicadores puros (Cálculos de velocidade, etc)
     novo_estado = atualizar_indicadores(estado_atual, pacote)
 
     commit_realizado = False
 
-    # Se for pacote inicial, resolver a dimensão e criar no banco se necessário
+    # Se for pacote inicial, resolver a dimensão e criar no banco
     tipo_lab = None
     if tipo == TipoPacote.INICIAL and novo_estado.id_corrida_banco is None:
         dimensao = pacote.get("dimensao")
@@ -143,25 +163,24 @@ async def receber_pacote_telemetria(
             tipo_lab = TipoLabirinto.DEZESSEIS
         elif int(dimensao) == 4:
             tipo_lab = TipoLabirinto.QUATRO
-        
+
         labirinto = Labirinto(tipo_labirinto=tipo_lab)
         session.add(labirinto)
         session.flush()
 
         corrida = Corrida(
-            sessao_hardware_id=sessao_hardware_id,
+            sessao_hardware_id=sessao_id,
             data_hora_inicio=datetime.now(UTC),
             id_labirinto=labirinto.id_labirinto,
             status_corrida=StatusCorrida.EM_ANDAMENTO,
-            tentativa=pacote.get("tentativa", 1),
-            bateria_inicial=pacote.get("bateria", 100.0)
+            bateria_inicial=pacote.get("bateria", 100)
         )
         session.add(corrida)
         session.flush()
 
         # Atualiza o estado com o ID real do banco
         novo_estado.id_corrida_banco = corrida.id_corrida
-        novo_estado.sessao_hardware_id = corrida.sessao_hardware_id
+        novo_estado.sessao_hardware_id = sessao_id
         _persistir_novos_alertas(session, estado_atual, novo_estado)
         session.commit()
         session.refresh(corrida)
@@ -206,7 +225,6 @@ async def receber_pacote_telemetria(
     if tipo == TipoPacote.FINAL and novo_estado.id_corrida_banco is not None:
         corrida = session.get(Corrida, novo_estado.id_corrida_banco)
         if corrida:
-            # O pacote FINAL sempre conclui a corrida; desafio_cumprido diferencia o resultado
             corrida.status_corrida = StatusCorrida.CONCLUIDA
             corrida.data_hora_fim = datetime.now(UTC)
             corrida.bateria_final = novo_estado.bateria_final
@@ -222,7 +240,7 @@ async def receber_pacote_telemetria(
         session.commit()
 
     # Salva o novo estado na memória
-    estados_ativos[sessao_hardware_id] = novo_estado
+    estados_ativos[sessao_id] = novo_estado
 
     # Faz o broadcast para o Dashboard via WebSocket
     estado_dict = _estado_to_dict(novo_estado)
@@ -232,8 +250,7 @@ async def receber_pacote_telemetria(
             "type": "SESSAO_INICIADA",
             "data": {
                 **estado_dict,
-                "dimensao": tipo_lab.value,
-                "tentativa": pacote.get("tentativa", 1),
+                "dimensao": tipo_lab.value if tipo_lab else None,
             }
         }
     else:
@@ -244,53 +261,46 @@ async def receber_pacote_telemetria(
 
     await manager.send_json_to_all_clients(evento)
     if tipo == TipoPacote.FINAL:
-        del estados_ativos[sessao_hardware_id]
-        connection_monitor.remover_corrida(sessao_hardware_id)
+        del estados_ativos[sessao_id]
+        connection_monitor.remover_corrida(sessao_id)
+        _set_sessao_ativa_id(None)
     return {"message": "Pacote processado com sucesso", "estado": estado_dict}
 
 
-async def _abortar_corridas_ativas(
+async def _abortar_corrida_ativa(
     session: Session,
-    novo_sessao_id: int,
+    sessao_id: int,
 ) -> None:
-    """Aborta corridas ativas quando uma nova sessão é iniciada.
+    """Aborta a corrida ativa quando uma nova sessão é iniciada.
 
     Garante que apenas uma corrida esteja ativa por vez,
-    abortando as anteriores com status ABORTADA no banco de dados.
+    abortando a anterior com status ABORTADA no banco de dados.
     """
-    ids_para_remover = [
-        sid for sid in estados_ativos
-        if sid != novo_sessao_id
-    ]
-
-    if not ids_para_remover:
+    estado = estados_ativos.pop(sessao_id, None)
+    if estado is None:
         return
 
-    for sid in ids_para_remover:
-        estado = estados_ativos.pop(sid)
+    # Atualizar registro no banco se existir
+    if estado.id_corrida_banco is not None:
+        corrida = session.get(Corrida, estado.id_corrida_banco)
+        if corrida and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO:
+            corrida.status_corrida = StatusCorrida.ABORTADA
+            corrida.data_hora_fim = datetime.now(UTC)
+            session.add(corrida)
 
-        # Atualizar registro no banco se existir
-        if estado.id_corrida_banco is not None:
-            corrida = session.get(Corrida, estado.id_corrida_banco)
-            if corrida and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO:
-                corrida.status_corrida = StatusCorrida.ABORTADA
-                corrida.data_hora_fim = datetime.now(UTC)
-                session.add(corrida)
-
-        connection_monitor.remover_corrida(sid)
-
+    connection_monitor.remover_corrida(sessao_id)
     session.commit()
 
     await manager.send_json_to_all_clients({
         "type": "SESSAO_ENCERRADA",
         "data": {
-            "sessoes_encerradas": ids_para_remover,
+            "sessao_encerrada": sessao_id,
             "motivo": "Nova sessão iniciada pelo Micromouse",
         }
     })
 
     logger.info(
-        "Corridas encerradas automaticamente: %s", ids_para_remover
+        "Corrida encerrada automaticamente: %s", sessao_id
     )
 
 

--- a/src/backend/app/routers/telemetria.py
+++ b/src/backend/app/routers/telemetria.py
@@ -236,6 +236,25 @@ async def receber_pacote_telemetria(
             session.commit()
             commit_realizado = True
 
+    # Se for heartbeat, apenas persistir eventuais alertas novos
+    if tipo == TipoPacote.HEARTBEAT and novo_estado.id_corrida_banco is not None:
+        if not commit_realizado and _persistir_novos_alertas(session, estado_atual, novo_estado):
+            session.commit()
+            commit_realizado = True
+
+    # Se for alerta de temperatura crítica, encerrar a corrida no banco
+    if tipo == TipoPacote.ALERTA_TEMPERATURA and novo_estado.id_corrida_banco is not None:
+        corrida = session.get(Corrida, novo_estado.id_corrida_banco)
+        if corrida and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO:
+            corrida.status_corrida = StatusCorrida.ABORTADA
+            corrida.data_hora_fim = datetime.now(UTC)
+            corrida.bateria_final = novo_estado.bateria_atual
+            corrida.tempo_total = novo_estado.tempo_final_ms
+            session.add(corrida)
+            _persistir_novos_alertas(session, estado_atual, novo_estado)
+            session.commit()
+            commit_realizado = True
+
     if not commit_realizado and _persistir_novos_alertas(session, estado_atual, novo_estado):
         session.commit()
 
@@ -253,6 +272,19 @@ async def receber_pacote_telemetria(
                 "dimensao": tipo_lab.value if tipo_lab else None,
             }
         }
+    elif tipo == TipoPacote.HEARTBEAT:
+        evento = {
+            "type": "HEARTBEAT",
+            "data": estado_dict
+        }
+    elif tipo == TipoPacote.ALERTA_TEMPERATURA:
+        evento = {
+            "type": "ALERTA_TEMPERATURA_CRITICA",
+            "data": {
+                **estado_dict,
+                "temp_c": pacote.get("temp_c"),
+            }
+        }
     else:
         evento = {
             "type": "ATUALIZACAO_TELEMETRIA",
@@ -260,7 +292,7 @@ async def receber_pacote_telemetria(
         }
 
     await manager.send_json_to_all_clients(evento)
-    if tipo == TipoPacote.FINAL:
+    if tipo in (TipoPacote.FINAL, TipoPacote.ALERTA_TEMPERATURA):
         del estados_ativos[sessao_id]
         connection_monitor.remover_corrida(sessao_id)
         _set_sessao_ativa_id(None)
@@ -321,6 +353,7 @@ def _estado_to_dict(estado: IndicadoresDesempenho) -> dict:
         "alerta_bateria_critica": estado.alerta_bateria_critica,
         "alerta_possivel_parada_inesperada": estado.alerta_possivel_parada_inesperada,
         "alerta_dado_invalido": estado.alerta_dado_invalido,
+        "alerta_temperatura_critica": estado.alerta_temperatura_critica,
         "log_alertas": [
             alerta.model_dump(mode="json")
             for alerta in estado.log_alertas

--- a/src/backend/app/schemas/telemetria.py
+++ b/src/backend/app/schemas/telemetria.py
@@ -1,10 +1,13 @@
 """
 Schemas Pydantic para pacotes de telemetria e indicadores de desempenho.
 
-Tipos de pacote:
-  - PacoteInicial: dados de início/configuração da corrida.
-  - PacoteMovimentacao: dados de movimentação durante a corrida.
-  - PacoteFinal: dados consolidados ao fim da corrida.
+Tipos de pacote (campo ``tipo`` — int):
+  - 0 → PacoteInicial: configuração inicial da corrida.
+  - 1 → PacoteMovimentacao: movimentação / descoberta de paredes.
+  - 2 → PacoteRota: rota otimizada calculada pelo Floodfill.
+  - 3 → PacoteFinal: dados consolidados ao fim da corrida.
+
+Schemas auxiliares:
   - IndicadoresDesempenho: estado consolidado dos indicadores do dashboard.
   - ResultadoValidacao: resultado da validação de um pacote.
 """
@@ -30,14 +33,17 @@ class StatusCorridaTelemetria(str, enum.Enum):
     FALHA = "falha"
 
 
-class TipoPacote(str, enum.Enum):
-    """Tipos de pacote de telemetria reconhecidos."""
+class TipoPacote(int, enum.Enum):
+    """Tipos de pacote de telemetria conforme telemetria.md.
 
-    INICIAL = "inicial"
-    MOVIMENTACAO = "movimentacao"
-    ROTA = "rota"
-    FINAL = "final"
-    INVALIDO = "invalido"
+    O campo ``tipo`` é o primeiro campo de todo pacote enviado pelo ESP32.
+    """
+
+    INICIAL = 0
+    MOVIMENTACAO = 1
+    ROTA = 2
+    FINAL = 3
+    INVALIDO = -1
 
 
 class TipoAlertaTelemetria(str, enum.Enum):
@@ -53,41 +59,51 @@ class TipoAlertaTelemetria(str, enum.Enum):
 
 
 class PacoteInicial(BaseModel):
-    """Pacote de início/configuração da corrida."""
+    """Pacote de configuração inicial (tipo=0).
 
-    id_corrida: int
+    Disparado uma única vez na largada.
+    """
+
+    tipo: int = Field(0)
     timestamp_ms: int = Field(ge=0)
-    dimensao: int | str
-    tentativa: int
-    bateria: float = Field(ge=0, le=100)
+    dimensao: int
+    bateria: int = Field(ge=0, le=100)
 
 
 class PacoteMovimentacao(BaseModel):
-    """Pacote de movimentação durante a corrida."""
+    """Pacote de movimentação / descoberta de paredes (tipo=1).
 
-    id_corrida: int
+    Disparado apenas ao mudar de célula.
+    """
+
+    tipo: int = Field(1)
     timestamp_ms: int = Field(ge=0)
-    x: int | float
-    y: int | float
-    w: int | float
-    bateria: float | None = Field(default=None, ge=0, le=100)
+    x: int
+    y: int
+    w: int = Field(ge=0, le=15)
 
 
 class PacoteRota(BaseModel):
-    """Pacote contendo a rota otimizada calculada."""
+    """Pacote contendo a rota otimizada calculada (tipo=2).
 
-    id_corrida: int
+    Disparado uma única vez após o cálculo do Floodfill.
+    """
+
+    tipo: int = Field(2)
     timestamp_ms: int = Field(ge=0)
-    rota: list[list[int | float]]
+    rota: list[list[int]]
 
 class PacoteFinal(BaseModel):
-    """Pacote consolidado ao fim da corrida."""
+    """Pacote consolidado ao fim da corrida (tipo=3).
 
-    id_corrida: int
+    Disparado uma única vez ao terminar/falhar.
+    """
+
+    tipo: int = Field(3)
     timestamp_ms: int = Field(ge=0)
     sucesso: bool
     v_med: float = Field(ge=0)
-    bateria: float = Field(ge=0, le=100)
+    bateria: int = Field(ge=0, le=100)
 
 
 class AlertaTelemetria(BaseModel):

--- a/src/backend/app/schemas/telemetria.py
+++ b/src/backend/app/schemas/telemetria.py
@@ -6,6 +6,8 @@ Tipos de pacote (campo ``tipo`` — int):
   - 1 → PacoteMovimentacao: movimentação / descoberta de paredes.
   - 2 → PacoteRota: rota otimizada calculada pelo Floodfill.
   - 3 → PacoteFinal: dados consolidados ao fim da corrida.
+  - 4 → PacoteHeartbeat: sinal periódico de vida da conexão.
+  - 5 → PacoteAlertaTemperatura: alerta crítico de temperatura.
 
 Schemas auxiliares:
   - IndicadoresDesempenho: estado consolidado dos indicadores do dashboard.
@@ -43,6 +45,8 @@ class TipoPacote(int, enum.Enum):
     MOVIMENTACAO = 1
     ROTA = 2
     FINAL = 3
+    HEARTBEAT = 4
+    ALERTA_TEMPERATURA = 5
     INVALIDO = -1
 
 
@@ -51,6 +55,7 @@ class TipoAlertaTelemetria(str, enum.Enum):
 
     BATERIA_CRITICA = "bateria_critica"
     POSSIVEL_PARADA_INESPERADA = "possivel_parada_inesperada"
+    TEMPERATURA_CRITICA = "temperatura_critica"
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +111,30 @@ class PacoteFinal(BaseModel):
     bateria: int = Field(ge=0, le=100)
 
 
+class PacoteHeartbeat(BaseModel):
+    """Sinal periódico de vida da conexão (tipo=4).
+
+    Enviado a cada 1,5 segundos. Permite detectar conexão perdida e
+    monitorar nível de bateria ao longo da corrida.
+    """
+
+    tipo: int = Field(4)
+    timestamp_ms: int = Field(ge=0)
+    bateria: int = Field(ge=0, le=100)
+
+
+class PacoteAlertaTemperatura(BaseModel):
+    """Alerta crítico de temperatura (tipo=5).
+
+    Enviado imediatamente quando a temperatura ultrapassa o limiar seguro.
+    A corrida é interrompida automaticamente após este pacote.
+    """
+
+    tipo: int = Field(5)
+    timestamp_ms: int = Field(ge=0)
+    temp_c: float
+
+
 class AlertaTelemetria(BaseModel):
     """Registro técnico de um alerta crítico detectado."""
 
@@ -136,6 +165,7 @@ class IndicadoresDesempenho(BaseModel):
     alerta_bateria_critica: bool = False
     alerta_possivel_parada_inesperada: bool = False
     alerta_dado_invalido: bool = False
+    alerta_temperatura_critica: bool = False
     log_alertas: list[AlertaTelemetria] = Field(default_factory=list)
 
     # --- Campos internos para cálculo acumulado de velocidade ---

--- a/src/backend/app/services/telemetria.py
+++ b/src/backend/app/services/telemetria.py
@@ -44,6 +44,8 @@ _TIPO_MAP: dict[int, TipoPacote] = {
     1: TipoPacote.MOVIMENTACAO,
     2: TipoPacote.ROTA,
     3: TipoPacote.FINAL,
+    4: TipoPacote.HEARTBEAT,
+    5: TipoPacote.ALERTA_TEMPERATURA,
 }
 """Tempo mínimo em ms para considerar uma parada inesperada."""
 
@@ -118,6 +120,10 @@ def validar_pacote(
         _validar_pacote_rota(packet, erros)
     elif tipo == TipoPacote.FINAL:
         _validar_pacote_final(packet, erros)
+    elif tipo == TipoPacote.HEARTBEAT:
+        _validar_pacote_heartbeat(packet, erros)
+    elif tipo == TipoPacote.ALERTA_TEMPERATURA:
+        _validar_pacote_alerta_temperatura(packet, erros)
 
     return ResultadoValidacao(valido=len(erros) == 0, erros=erros)
 
@@ -212,10 +218,26 @@ def _validar_pacote_final(packet: dict, erros: list[str]) -> None:
         erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
 
+def _validar_pacote_heartbeat(packet: dict, erros: list[str]) -> None:
+    """Valida campos do pacote Heartbeat (tipo=4)."""
+    bateria = packet.get("bateria")
+    if bateria is None:
+        erros.append("Campo 'bateria' ausente no pacote heartbeat.")
+    elif not isinstance(bateria, int):
+        erros.append(f"Campo 'bateria' deve ser um número inteiro (recebido: {bateria}).")
+    elif not (0 <= bateria <= 100):
+        erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
-# ---------------------------------------------------------------------------
-# Cálculo de velocidade de um segmento
-# ---------------------------------------------------------------------------
+
+def _validar_pacote_alerta_temperatura(packet: dict, erros: list[str]) -> None:
+    """Valida campos do pacote Alerta Crítico de Temperatura (tipo=5)."""
+    temp_c = packet.get("temp_c")
+    if temp_c is None:
+        erros.append("Campo 'temp_c' ausente no pacote de alerta de temperatura.")
+    elif not isinstance(temp_c, (int, float)):
+        erros.append(f"Campo 'temp_c' deve ser numérico (recebido: {temp_c}).")
+
+
 
 
 def calcular_velocidade_segmento(
@@ -303,6 +325,10 @@ def atualizar_indicadores(
         _processar_pacote_movimentacao(novo_estado, pacote)
     elif tipo == TipoPacote.FINAL:
         _processar_pacote_final(novo_estado, pacote)
+    elif tipo == TipoPacote.HEARTBEAT:
+        _processar_pacote_heartbeat(novo_estado, pacote)
+    elif tipo == TipoPacote.ALERTA_TEMPERATURA:
+        _processar_pacote_alerta_temperatura(novo_estado, pacote)
 
     return novo_estado
 
@@ -412,6 +438,48 @@ def _processar_pacote_final(
         else StatusCorridaTelemetria.FALHA
     )
     _resetar_alerta_parada_inesperada(estado)
+
+
+def _processar_pacote_heartbeat(
+    estado: IndicadoresDesempenho, pacote: dict
+) -> None:
+    """Processa um Heartbeat (tipo=4): atualiza bateria e timestamp."""
+    estado.bateria_atual = pacote["bateria"]
+    estado.ultimo_timestamp_ms = pacote["timestamp_ms"]
+    _atualizar_alerta_bateria_critica(
+        estado,
+        bateria=pacote["bateria"],
+        timestamp_ms=pacote["timestamp_ms"],
+    )
+
+
+def _processar_pacote_alerta_temperatura(
+    estado: IndicadoresDesempenho, pacote: dict
+) -> None:
+    """Processa um Alerta Crítico de Temperatura (tipo=5).
+
+    Interrompe a corrida automaticamente e registra o alerta.
+    """
+    ts = pacote["timestamp_ms"]
+    temp_c = pacote["temp_c"]
+    estado.ultimo_timestamp_ms = ts
+
+    # Registrar alerta de temperatura crítica
+    _registrar_alerta(
+        estado,
+        tipo=TipoAlertaTelemetria.TEMPERATURA_CRITICA,
+        mensagem=f"Temperatura crítica detectada: {temp_c}°C.",
+        timestamp_ms=ts,
+    )
+    estado.alerta_temperatura_critica = True
+
+    # Interromper a corrida automaticamente
+    if estado.status_corrida == StatusCorridaTelemetria.EM_ANDAMENTO:
+        estado.status_corrida = StatusCorridaTelemetria.FALHA
+        estado.sucesso = False
+        estado.tempo_final_ms = ts
+        estado.tempo_decorrido_ms = ts
+        _resetar_alerta_parada_inesperada(estado)
 
 
 def _corrida_aceita_alerta_de_parada(estado: IndicadoresDesempenho) -> bool:

--- a/src/backend/app/services/telemetria.py
+++ b/src/backend/app/services/telemetria.py
@@ -38,6 +38,13 @@ BATERIA_CRITICA_THRESHOLD: float = 10.0
 """Limiar percentual em que a bateria é considerada crítica."""
 
 PARADA_INESPERADA_THRESHOLD_MS: int = 3000
+
+_TIPO_MAP: dict[int, TipoPacote] = {
+    0: TipoPacote.INICIAL,
+    1: TipoPacote.MOVIMENTACAO,
+    2: TipoPacote.ROTA,
+    3: TipoPacote.FINAL,
+}
 """Tempo mínimo em ms para considerar uma parada inesperada."""
 
 
@@ -57,35 +64,16 @@ def criar_estado_inicial() -> IndicadoresDesempenho:
 
 
 def identificar_tipo_pacote(packet: dict | None) -> TipoPacote:
-    """Identifica o tipo do pacote de telemetria com base nos campos presentes.
+    """Identifica o tipo do pacote via campo ``tipo`` (int).
 
-    Retorna:
-        TipoPacote.INICIAL — possui ``dimensao``, ``tentativa`` e ``bateria``.
-        TipoPacote.MOVIMENTACAO — possui ``x``, ``y`` e ``w``.
-        TipoPacote.FINAL — possui ``sucesso``, ``v_med`` e ``bateria``.
-        TipoPacote.INVALIDO — qualquer outro caso.
+    Retorna TipoPacote correspondente ao valor, ou INVALIDO.
     """
     if not isinstance(packet, dict):
         return TipoPacote.INVALIDO
-
-    # Pacote inicial: dimensao + tentativa + bateria (sem 'sucesso' para
-    # desambiguar do pacote final que também tem bateria)
-    if "dimensao" in packet and "tentativa" in packet and "bateria" in packet:
-        return TipoPacote.INICIAL
-
-    # Pacote final: sucesso + v_med + bateria
-    if "sucesso" in packet and "v_med" in packet and "bateria" in packet:
-        return TipoPacote.FINAL
-
-    # Pacote de movimentação: x + y + w
-    if "x" in packet and "y" in packet and "w" in packet:
-        return TipoPacote.MOVIMENTACAO
-
-    # Pacote de rota: rota (lista)
-    if "rota" in packet and isinstance(packet["rota"], list):
-        return TipoPacote.ROTA
-
-    return TipoPacote.INVALIDO
+    tipo_raw = packet.get("tipo")
+    if not isinstance(tipo_raw, int):
+        return TipoPacote.INVALIDO
+    return _TIPO_MAP.get(tipo_raw, TipoPacote.INVALIDO)
 
 
 # ---------------------------------------------------------------------------
@@ -98,29 +86,21 @@ def validar_pacote(
     tipo: TipoPacote,
     ultimo_timestamp_ms: int | None = None,
 ) -> ResultadoValidacao:
-    """Valida um pacote de telemetria conforme seu tipo.
-
-    Args:
-        packet: dicionário com os dados do pacote.
-        tipo: tipo identificado do pacote.
-        ultimo_timestamp_ms: último timestamp válido recebido na corrida.
-
-    Returns:
-        ResultadoValidacao com flag ``valido`` e lista de ``erros``.
-    """
+    """Valida um pacote de telemetria conforme seu tipo."""
     erros: list[str] = []
 
     if tipo == TipoPacote.INVALIDO:
         erros.append("Tipo de pacote não reconhecido.")
         return ResultadoValidacao(valido=False, erros=erros)
 
-    # --- Campos obrigatórios gerais ---
-    id_corrida = packet.get("id_corrida")
-    if id_corrida is None:
-        erros.append("Campo 'id_corrida' ausente.")
-    elif not isinstance(id_corrida, int):
-        erros.append(f"Campo 'id_corrida' deve ser um número inteiro (recebido: {id_corrida}).")
+    # --- Campo 'tipo' obrigatório ---
+    tipo_val = packet.get("tipo")
+    if tipo_val is None:
+        erros.append("Campo 'tipo' ausente.")
+    elif not isinstance(tipo_val, int):
+        erros.append(f"Campo 'tipo' deve ser um número inteiro (recebido: {tipo_val}).")
 
+    # --- timestamp_ms obrigatório ---
     ts = packet.get("timestamp_ms")
     if ts is None:
         erros.append("Campo 'timestamp_ms' ausente.")
@@ -149,17 +129,11 @@ def _validar_pacote_inicial(packet: dict, erros: list[str]) -> None:
     elif dimensao not in (4, 8, 16):
         erros.append(f"Dimensão inválida: deve ser 4, 8 ou 16 (recebido: {dimensao}).")
 
-    tentativa = packet.get("tentativa")
-    if tentativa is None:
-        erros.append("Campo 'tentativa' ausente no pacote inicial.")
-    elif tentativa not in (1, 2, 3):
-        erros.append(f"Tentativa fora do limite: deve ser 1, 2 ou 3 (recebido: {tentativa}).")
-
     bateria = packet.get("bateria")
     if bateria is None:
         erros.append("Campo 'bateria' ausente no pacote inicial.")
-    elif not isinstance(bateria, (int, float)):
-        erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
+    elif not isinstance(bateria, int):
+        erros.append(f"Campo 'bateria' deve ser um número inteiro (recebido: {bateria}).")
     elif not (0 <= bateria <= 100):
         erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
@@ -169,12 +143,21 @@ def _validar_pacote_movimentacao(
     erros: list[str],
     ultimo_timestamp_ms: int | None,
 ) -> None:
-    for campo in ("x", "y", "w"):
+    for campo in ("x", "y"):
         valor = packet.get(campo)
         if valor is None:
             erros.append(f"Campo '{campo}' ausente no pacote de movimentação.")
-        elif not isinstance(valor, (int, float)):
-            erros.append(f"Campo '{campo}' deve ser numérico (recebido: {valor}).")
+        elif not isinstance(valor, int):
+            erros.append(f"Campo '{campo}' deve ser um número inteiro (recebido: {valor}).")
+
+    # Bitmask de paredes: int no range [0, 15]
+    w = packet.get("w")
+    if w is None:
+        erros.append("Campo 'w' ausente no pacote de movimentação.")
+    elif not isinstance(w, int):
+        erros.append(f"Campo 'w' deve ser um número inteiro (recebido: {w}).")
+    elif not (0 <= w <= 15):
+        erros.append(f"Campo 'w' fora do range [0, 15] (recebido: {w}).")
 
     # Timestamp não-regressivo
     ts = packet.get("timestamp_ms")
@@ -186,14 +169,6 @@ def _validar_pacote_movimentacao(
         erros.append(
             f"Timestamp regressivo: {ts} < último válido {ultimo_timestamp_ms}."
         )
-
-    # Bateria opcional — se presente, validar range
-    bateria = packet.get("bateria")
-    if bateria is not None:
-        if not isinstance(bateria, (int, float)):
-            erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
-        elif not (0 <= bateria <= 100):
-            erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
 def _validar_pacote_rota(packet: dict, erros: list[str]) -> None:
     """Valida as regras específicas do pacote de rota otimizada."""
@@ -210,8 +185,8 @@ def _validar_pacote_rota(packet: dict, erros: list[str]) -> None:
         if not isinstance(pt, list) or len(pt) != 2:
             erros.append(f"Ponto {i} da rota inválido: deve ser [x, y] (recebido: {pt}).")
             continue
-        if not isinstance(pt[0], (int, float)) or not isinstance(pt[1], (int, float)):
-            erros.append(f"Coordenadas do ponto {i} devem ser numéricas (recebido: {pt}).")
+        if not isinstance(pt[0], int) or not isinstance(pt[1], int):
+            erros.append(f"Coordenadas do ponto {i} devem ser inteiras (recebido: {pt}).")
 
 def _validar_pacote_final(packet: dict, erros: list[str]) -> None:
     sucesso = packet.get("sucesso")
@@ -231,8 +206,8 @@ def _validar_pacote_final(packet: dict, erros: list[str]) -> None:
     bateria = packet.get("bateria")
     if bateria is None:
         erros.append("Campo 'bateria' ausente no pacote final.")
-    elif not isinstance(bateria, (int, float)):
-        erros.append(f"Campo 'bateria' deve ser numérico (recebido: {bateria}).")
+    elif not isinstance(bateria, int):
+        erros.append(f"Campo 'bateria' deve ser um número inteiro (recebido: {bateria}).")
     elif not (0 <= bateria <= 100):
         erros.append(f"Bateria fora do range [0, 100] (recebido: {bateria}).")
 
@@ -341,7 +316,6 @@ def _processar_pacote_inicial(
     estado: IndicadoresDesempenho, pacote: dict
 ) -> None:
     """Atualiza indicadores com dados do pacote inicial."""
-    estado.sessao_hardware_id = pacote["id_corrida"]
     estado.bateria_inicial = pacote["bateria"]
     estado.bateria_atual = pacote["bateria"]
     estado.status_corrida = StatusCorridaTelemetria.EM_ANDAMENTO
@@ -408,16 +382,6 @@ def _processar_pacote_movimentacao(
     estado._ultima_posicao_y = y_atual
     estado.tempo_decorrido_ms = ts_atual
     estado.ultimo_timestamp_ms = ts_atual
-
-    # Atualizar bateria se presente
-    bateria = pacote.get("bateria")
-    if bateria is not None and isinstance(bateria, (int, float)) and 0 <= bateria <= 100:
-        estado.bateria_atual = bateria
-        _atualizar_alerta_bateria_critica(
-            estado,
-            bateria=bateria,
-            timestamp_ms=ts_atual,
-        )
 
 
 def _processar_pacote_final(

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -11,7 +11,8 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.database import get_session
 from app.config import settings
-from app.routers.telemetria import estados_ativos
+from app.routers.telemetria import estados_ativos, _set_sessao_ativa_id
+import app.routers.telemetria as _tel_router
 from app.services.connection_monitor import connection_monitor
 
 # Detecta se está dentro de um container Docker
@@ -111,7 +112,11 @@ def client_fixture(session: Session):
 def limpar_estados_ativos():
     """Isola o estado em memória da telemetria entre testes."""
     estados_ativos.clear()
+    _set_sessao_ativa_id(None)
+    _tel_router._contador_sessao = 0
     connection_monitor.clear()
     yield
     estados_ativos.clear()
+    _set_sessao_ativa_id(None)
+    _tel_router._contador_sessao = 0
     connection_monitor.clear()

--- a/src/backend/tests/test_alertas_funcionais.py
+++ b/src/backend/tests/test_alertas_funcionais.py
@@ -1,121 +1,51 @@
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
-
 from app.models.evento import Evento
-from app.routers.telemetria import estados_ativos
+from app.routers.telemetria import estados_ativos, _get_sessao_ativa_id
 from app.schemas.telemetria import StatusCorridaTelemetria
 
 
-def _buscar_eventos_da_corrida(session: Session, id_corrida: int) -> list[Evento]:
-    return list(
-        session.exec(
-            select(Evento)
-            .where(Evento.id_corrida == id_corrida)
-            .order_by(Evento.id_evento)
-        )
-    )
+def _buscar_eventos(session, id_corrida):
+    return list(session.exec(select(Evento).where(Evento.id_corrida == id_corrida).order_by(Evento.id_evento)))
 
 
 def test_alerta_bateria_critica_e_persistido(client: TestClient, session: Session):
-    response = client.post(
-        "/api/telemetria/pacote",
-        json={
-            "id_corrida": 101,
-            "timestamp_ms": 0,
-            "dimensao": 4,
-            "tentativa": 1,
-            "bateria": 10,
-        },
-    )
-
-    assert response.status_code == 201
-    estado = response.json()["estado"]
-    assert estado["alerta_bateria_critica"] is True
-    assert estado["log_alertas"][0]["tipo"] == "bateria_critica"
-
-    eventos = _buscar_eventos_da_corrida(session, estado["id_corrida_banco"])
-    assert len(eventos) == 1
-    assert eventos[0].tipo_evento == "bateria_critica"
-    assert eventos[0].descricao == "Bateria crítica detectada."
-    assert eventos[0].timestamp_ms == 0
-    assert eventos[0].id_corrida == estado["id_corrida_banco"]
+    r = client.post("/api/telemetria/pacote", json={"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 10})
+    assert r.status_code == 201
+    estado = r.json()["estado"]
+    assert estado["alerta_bateria_critica"] and estado["log_alertas"][0]["tipo"] == "bateria_critica"
+    eventos = _buscar_eventos(session, estado["id_corrida_banco"])
+    assert len(eventos) == 1 and eventos[0].tipo_evento == "bateria_critica"
 
 
 def test_alerta_parada_inesperada_e_persistido(client: TestClient, session: Session):
-    response_inicial = client.post(
-        "/api/telemetria/pacote",
-        json={
-            "id_corrida": 202,
-            "timestamp_ms": 0,
-            "dimensao": 4,
-            "tentativa": 1,
-            "bateria": 85,
-        },
-    )
-    assert response_inicial.status_code == 201
-    id_corrida_banco = response_inicial.json()["estado"]["id_corrida_banco"]
-
-    for pacote in (
-        {"id_corrida": 202, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
-        {"id_corrida": 202, "timestamp_ms": 2500, "x": 0, "y": 0, "w": 0},
-        {"id_corrida": 202, "timestamp_ms": 4501, "x": 0, "y": 0, "w": 0},
+    r0 = client.post("/api/telemetria/pacote", json={"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+    idb = r0.json()["estado"]["id_corrida_banco"]
+    for p in (
+        {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
+        {"tipo": 1, "timestamp_ms": 2500, "x": 0, "y": 0, "w": 0},
+        {"tipo": 1, "timestamp_ms": 4501, "x": 0, "y": 0, "w": 0},
     ):
-        response = client.post("/api/telemetria/pacote", json=pacote)
-        assert response.status_code == 201
-
-    estado = response.json()["estado"]
-    assert estado["alerta_possivel_parada_inesperada"] is True
-    assert estado["log_alertas"][-1]["tipo"] == "possivel_parada_inesperada"
-
-    eventos = _buscar_eventos_da_corrida(session, id_corrida_banco)
-    assert len(eventos) == 1
-    assert eventos[0].tipo_evento == "possivel_parada_inesperada"
-    assert eventos[0].descricao == "Possível parada inesperada detectada."
-    assert eventos[0].timestamp_ms == 4501
+        r = client.post("/api/telemetria/pacote", json=p)
+        assert r.status_code == 201
+    estado = r.json()["estado"]
+    assert estado["alerta_possivel_parada_inesperada"]
+    eventos = _buscar_eventos(session, idb)
+    assert len(eventos) == 1 and eventos[0].tipo_evento == "possivel_parada_inesperada"
 
 
-def test_alerta_de_parada_nao_dispara_fora_de_corrida_ativa(
-    client: TestClient,
-    session: Session,
-):
-    for sessao_hardware_id, status in (
-        (301, StatusCorridaTelemetria.AGUARDANDO),
-        (302, StatusCorridaTelemetria.FALHA),
-        (303, StatusCorridaTelemetria.CONCLUIDA),
-    ):
-        response_inicial = client.post(
-            "/api/telemetria/pacote",
-            json={
-                "id_corrida": sessao_hardware_id,
-                "timestamp_ms": 0,
-                "dimensao": 4,
-                "tentativa": 1,
-                "bateria": 85,
-            },
-        )
-        assert response_inicial.status_code == 201
-
-        estado_inicial = response_inicial.json()["estado"]
-        id_corrida_banco = estado_inicial["id_corrida_banco"]
-        estados_ativos[sessao_hardware_id].status_corrida = status
-
-        for pacote in (
-            {"id_corrida": sessao_hardware_id, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
-            {"id_corrida": sessao_hardware_id, "timestamp_ms": 5000, "x": 0, "y": 0, "w": 0},
+def test_alerta_de_parada_nao_dispara_fora_de_corrida_ativa(client: TestClient, session: Session):
+    for status in (StatusCorridaTelemetria.AGUARDANDO, StatusCorridaTelemetria.FALHA, StatusCorridaTelemetria.CONCLUIDA):
+        r0 = client.post("/api/telemetria/pacote", json={"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+        idb = r0.json()["estado"]["id_corrida_banco"]
+        sid = _get_sessao_ativa_id()
+        estados_ativos[sid].status_corrida = status
+        for p in (
+            {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
+            {"tipo": 1, "timestamp_ms": 5000, "x": 0, "y": 0, "w": 0},
         ):
-            response = client.post("/api/telemetria/pacote", json=pacote)
-            assert response.status_code == 201
-
-        estado = response.json()["estado"]
-        assert estado["status_corrida"] == status.value
-        assert estado["alerta_possivel_parada_inesperada"] is False
-        assert not any(
-            alerta["tipo"] == "possivel_parada_inesperada"
-            for alerta in estado["log_alertas"]
-        )
-
-        eventos = _buscar_eventos_da_corrida(session, id_corrida_banco)
-        assert not any(
-            evento.tipo_evento == "possivel_parada_inesperada"
-            for evento in eventos
-        )
+            r = client.post("/api/telemetria/pacote", json=p)
+            assert r.status_code == 201
+        estado = r.json()["estado"]
+        assert not estado["alerta_possivel_parada_inesperada"]
+        assert not any(e.tipo_evento == "possivel_parada_inesperada" for e in _buscar_eventos(session, idb))

--- a/src/backend/tests/test_novos_pacotes.py
+++ b/src/backend/tests/test_novos_pacotes.py
@@ -1,0 +1,212 @@
+"""Testes para os novos pacotes: Heartbeat (tipo=4) e Alerta de Temperatura (tipo=5)."""
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.schemas.telemetria import TipoPacote, TipoAlertaTelemetria, StatusCorridaTelemetria
+from app.services.telemetria import (
+    atualizar_indicadores,
+    criar_estado_inicial,
+    identificar_tipo_pacote,
+    validar_pacote,
+)
+from app.models.corrida import Corrida
+from app.models.evento import Evento
+from app.models.enums import StatusCorrida
+from app.routers.telemetria import _get_sessao_ativa_id
+
+# =========================================================================
+# Pacotes de teste
+# =========================================================================
+
+PACOTE_INICIAL = {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 95}
+PACOTE_HEARTBEAT = {"tipo": 4, "timestamp_ms": 1500, "bateria": 93}
+PACOTE_HEARTBEAT_CRITICA = {"tipo": 4, "timestamp_ms": 2000, "bateria": 5}
+PACOTE_TEMP = {"tipo": 5, "timestamp_ms": 7800, "temp_c": 61.0}
+PACOTE_TEMP_SEM_CAMPO = {"tipo": 5, "timestamp_ms": 7800}
+PACOTE_FINAL = {"tipo": 3, "timestamp_ms": 30000, "sucesso": True, "v_med": 10.0, "bateria": 85}
+
+
+# =========================================================================
+# Identificação de tipo
+# =========================================================================
+
+class TestIdentificarTiposNovos:
+    def test_heartbeat_identificado(self):
+        assert identificar_tipo_pacote(PACOTE_HEARTBEAT) == TipoPacote.HEARTBEAT
+
+    def test_alerta_temperatura_identificado(self):
+        assert identificar_tipo_pacote(PACOTE_TEMP) == TipoPacote.ALERTA_TEMPERATURA
+
+
+# =========================================================================
+# Validação de Heartbeat
+# =========================================================================
+
+class TestValidarHeartbeat:
+    def test_heartbeat_valido(self):
+        assert validar_pacote(PACOTE_HEARTBEAT, TipoPacote.HEARTBEAT).valido
+
+    def test_heartbeat_sem_bateria_rejeitado(self):
+        r = validar_pacote({"tipo": 4, "timestamp_ms": 1000}, TipoPacote.HEARTBEAT)
+        assert not r.valido and any("bateria" in e for e in r.erros)
+
+    def test_heartbeat_bateria_float_rejeitado(self):
+        r = validar_pacote({"tipo": 4, "timestamp_ms": 1000, "bateria": 90.5}, TipoPacote.HEARTBEAT)
+        assert not r.valido and any("inteiro" in e for e in r.erros)
+
+    def test_heartbeat_bateria_fora_do_range(self):
+        r = validar_pacote({"tipo": 4, "timestamp_ms": 1000, "bateria": 150}, TipoPacote.HEARTBEAT)
+        assert not r.valido and any("range" in e for e in r.erros)
+
+    def test_heartbeat_sem_timestamp(self):
+        r = validar_pacote({"tipo": 4, "bateria": 80}, TipoPacote.HEARTBEAT)
+        assert not r.valido and any("timestamp_ms" in e for e in r.erros)
+
+
+# =========================================================================
+# Validação de AlertaTemperatura
+# =========================================================================
+
+class TestValidarAlertaTemperatura:
+    def test_alerta_temperatura_valido(self):
+        assert validar_pacote(PACOTE_TEMP, TipoPacote.ALERTA_TEMPERATURA).valido
+
+    def test_alerta_temperatura_sem_temp_c(self):
+        r = validar_pacote(PACOTE_TEMP_SEM_CAMPO, TipoPacote.ALERTA_TEMPERATURA)
+        assert not r.valido and any("temp_c" in e for e in r.erros)
+
+    def test_alerta_temperatura_temp_c_string(self):
+        r = validar_pacote({"tipo": 5, "timestamp_ms": 100, "temp_c": "quente"}, TipoPacote.ALERTA_TEMPERATURA)
+        assert not r.valido
+
+    def test_alerta_temperatura_temp_c_int_aceito(self):
+        # int é aceito (isinstance(61, (int, float)) == True)
+        assert validar_pacote({"tipo": 5, "timestamp_ms": 100, "temp_c": 61}, TipoPacote.ALERTA_TEMPERATURA).valido
+
+
+# =========================================================================
+# Processamento de Heartbeat (service)
+# =========================================================================
+
+class TestProcessarHeartbeat:
+    def test_heartbeat_atualiza_bateria(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
+        assert e.bateria_atual == 93
+
+    def test_heartbeat_atualiza_timestamp(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
+        assert e.ultimo_timestamp_ms == 1500
+
+    def test_heartbeat_nao_muda_status_corrida(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
+        assert e.status_corrida == StatusCorridaTelemetria.EM_ANDAMENTO
+
+    def test_heartbeat_bateria_critica_ativa_alerta(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_HEARTBEAT_CRITICA)
+        assert e.alerta_bateria_critica
+        assert e.log_alertas[-1].tipo == TipoAlertaTelemetria.BATERIA_CRITICA
+
+    def test_heartbeat_invalido_sem_sessao_nao_altera(self):
+        e = criar_estado_inicial()
+        e2 = atualizar_indicadores(e, PACOTE_HEARTBEAT)
+        # sem sessão ativa, heartbeat é pacote válido — apenas atualiza ts/bateria
+        assert e2.bateria_atual == 93
+
+
+# =========================================================================
+# Processamento de AlertaTemperatura (service)
+# =========================================================================
+
+class TestProcessarAlertaTemperatura:
+    def test_alerta_temperatura_aborta_corrida(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_TEMP)
+        assert e.status_corrida == StatusCorridaTelemetria.FALHA
+        assert e.sucesso is False
+
+    def test_alerta_temperatura_registra_log(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_TEMP)
+        assert any(a.tipo == TipoAlertaTelemetria.TEMPERATURA_CRITICA for a in e.log_alertas)
+
+    def test_alerta_temperatura_seta_flag(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_TEMP)
+        assert e.alerta_temperatura_critica
+
+    def test_alerta_temperatura_fixa_tempo(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_TEMP)
+        assert e.tempo_final_ms == PACOTE_TEMP["timestamp_ms"]
+
+    def test_alerta_temperatura_nao_aborta_corrida_ja_encerrada(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_FINAL)
+        assert e.status_corrida == StatusCorridaTelemetria.CONCLUIDA
+        e2 = atualizar_indicadores(e, PACOTE_TEMP)
+        # Não deve mudar o status de CONCLUIDA para FALHA
+        assert e2.status_corrida == StatusCorridaTelemetria.CONCLUIDA
+
+
+# =========================================================================
+# Integração via HTTP (router)
+# =========================================================================
+
+class TestHeartbeatRouter:
+    def test_heartbeat_retorna_201(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        r = client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT)
+        assert r.status_code == 201
+
+    def test_heartbeat_sem_sessao_retorna_409(self, client: TestClient):
+        r = client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT)
+        assert r.status_code == 409
+
+    def test_heartbeat_atualiza_bateria_no_estado(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        r = client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT)
+        assert r.json()["estado"]["bateria_atual"] == 93
+
+    def test_heartbeat_persiste_alerta_bateria_critica(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
+        client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT_CRITICA)
+        eventos = list(session.exec(select(Evento).where(Evento.id_corrida == idb)))
+        assert any(e.tipo_evento == "bateria_critica" for e in eventos)
+
+
+class TestAlertaTemperaturaRouter:
+    def test_alerta_temperatura_retorna_201(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        r = client.post("/api/telemetria/pacote", json=PACOTE_TEMP)
+        assert r.status_code == 201
+
+    def test_alerta_temperatura_encerra_sessao_em_memoria(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        client.post("/api/telemetria/pacote", json=PACOTE_TEMP)
+        assert _get_sessao_ativa_id() is None
+
+    def test_alerta_temperatura_sem_sessao_retorna_409(self, client: TestClient):
+        r = client.post("/api/telemetria/pacote", json=PACOTE_TEMP)
+        assert r.status_code == 409
+
+    def test_alerta_temperatura_marca_corrida_como_abortada_no_banco(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
+        client.post("/api/telemetria/pacote", json=PACOTE_TEMP)
+        corrida = session.get(Corrida, idb)
+        assert corrida.status_corrida == StatusCorrida.ABORTADA
+
+    def test_alerta_temperatura_persiste_evento_no_banco(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
+        client.post("/api/telemetria/pacote", json=PACOTE_TEMP)
+        eventos = list(session.exec(select(Evento).where(Evento.id_corrida == idb)))
+        assert any(e.tipo_evento == "temperatura_critica" for e in eventos)
+
+    def test_alerta_temperatura_sem_temp_c_retorna_422(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        r = client.post("/api/telemetria/pacote", json=PACOTE_TEMP_SEM_CAMPO)
+        assert r.status_code == 422

--- a/src/backend/tests/test_persistencia.py
+++ b/src/backend/tests/test_persistencia.py
@@ -1,17 +1,5 @@
-"""Testes de persistência — TASK-SW-16A.
-
-Cobre os critérios de aceite:
-  ✓ Modelo de banco para dados da corrida.
-  ✓ Salva dados consolidados ao receber evento de encerramento.
-  ✓ Registra trajeto percorrido durante a execução.
-  ✓ Registra dados de telemetria recebidos.
-  ✓ Registra tempo total da corrida.
-  ✓ Registra resultado do desafio.
-  ✓ Registra tipo/dimensão do labirinto.
-  ✓ Impede persistência com campos obrigatórios ausentes.
-"""
+"""Testes de persistência — pacotes conforme telemetria.md."""
 from datetime import datetime, UTC
-
 import pytest
 from sqlmodel import Session, select
 from fastapi.testclient import TestClient
@@ -20,340 +8,118 @@ from app.models.corrida import Corrida
 from app.models.labirinto import Labirinto
 from app.models.percurso import Percurso
 from app.models.celula import Celula
-from app.models.evento import Evento
 from app.models.enums import StatusCorrida, TipoLabirinto
-from app.schemas.corrida import (
-    CorridaStart,
-    CorridaSave,
-    CelulaCreate,
-    ConexaoCreate,
-    PercursoCreate,
-)
+from app.schemas.corrida import CorridaStart, CorridaSave, CelulaCreate, PercursoCreate
 from app.services.registro import RegistroError, iniciar_corrida, salvar_corrida
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-PACOTE_INICIAL = {
-    "id_corrida": 42,
-    "timestamp_ms": 0,
-    "dimensao": 4,
-    "tentativa": 1,
-    "bateria": 100.0,
-}
-
-PACOTE_MOV_1 = {
-    "id_corrida": 42,
-    "timestamp_ms": 1000,
-    "x": 1,
-    "y": 0,
-    "w": 0,
-    "bateria": 98.0,
-}
-
-PACOTE_MOV_2 = {
-    "id_corrida": 42,
-    "timestamp_ms": 2000,
-    "x": 2,
-    "y": 0,
-    "w": 0,
-}
-
-PACOTE_ROTA = {
-    "id_corrida": 42,
-    "timestamp_ms": 3000,
-    "rota": [[0,0], [1,0], [2,0]],
-}
-
-PACOTE_FINAL = {
-    "id_corrida": 42,
-    "timestamp_ms": 5000,
-    "sucesso": True,
-    "v_med": 25.0,
-    "bateria": 85.0,
-}
-
-
-# ---------------------------------------------------------------------------
-# Testes do serviço de registro (registro.py)
-# ---------------------------------------------------------------------------
-
+PACOTE_INICIAL = {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 100}
+PACOTE_MOV_1 = {"tipo": 1, "timestamp_ms": 1000, "x": 1, "y": 0, "w": 0}
+PACOTE_MOV_2 = {"tipo": 1, "timestamp_ms": 2000, "x": 2, "y": 0, "w": 0}
+PACOTE_ROTA = {"tipo": 2, "timestamp_ms": 3000, "rota": [[0, 0], [1, 0], [2, 0]]}
+PACOTE_FINAL = {"tipo": 3, "timestamp_ms": 5000, "sucesso": True, "v_med": 25.0, "bateria": 85}
 
 class TestIniciarCorrida:
-    """CA: Existe uma estrutura/modelo de banco para armazenar dados da corrida."""
-
     def test_cria_labirinto_e_corrida(self, session: Session):
-        payload = CorridaStart(
-            tipo_labirinto=TipoLabirinto.QUATRO,
-            data_hora_inicio=datetime.now(UTC),
-        )
-        corrida = iniciar_corrida(session, payload)
-
-        assert corrida.id_corrida is not None
-        assert corrida.id_labirinto is not None
-        assert corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
+        corrida = iniciar_corrida(session, CorridaStart(tipo_labirinto=TipoLabirinto.QUATRO, data_hora_inicio=datetime.now(UTC)))
+        assert corrida.id_corrida is not None and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
 
     def test_labirinto_tem_tipo_correto_4x4(self, session: Session):
-        payload = CorridaStart(
-            tipo_labirinto=TipoLabirinto.QUATRO,
-            data_hora_inicio=datetime.now(UTC),
-        )
-        corrida = iniciar_corrida(session, payload)
-        labirinto = session.get(Labirinto, corrida.id_labirinto)
-
-        assert labirinto is not None
-        assert labirinto.tipo_labirinto == TipoLabirinto.QUATRO
+        corrida = iniciar_corrida(session, CorridaStart(tipo_labirinto=TipoLabirinto.QUATRO, data_hora_inicio=datetime.now(UTC)))
+        lab = session.get(Labirinto, corrida.id_labirinto)
+        assert lab.tipo_labirinto == TipoLabirinto.QUATRO
 
     def test_labirinto_tem_tipo_correto_16x16(self, session: Session):
-        payload = CorridaStart(
-            tipo_labirinto=TipoLabirinto.DEZESSEIS,
-            data_hora_inicio=datetime.now(UTC),
-        )
-        corrida = iniciar_corrida(session, payload)
-        labirinto = session.get(Labirinto, corrida.id_labirinto)
-
-        assert labirinto.tipo_labirinto == TipoLabirinto.DEZESSEIS
+        corrida = iniciar_corrida(session, CorridaStart(tipo_labirinto=TipoLabirinto.DEZESSEIS, data_hora_inicio=datetime.now(UTC)))
+        assert session.get(Labirinto, corrida.id_labirinto).tipo_labirinto == TipoLabirinto.DEZESSEIS
 
     def test_data_hora_inicio_e_salva(self, session: Session):
-        agora = datetime.now(UTC)
-        payload = CorridaStart(
-            tipo_labirinto=TipoLabirinto.OITO,
-            data_hora_inicio=agora,
-        )
-        corrida = iniciar_corrida(session, payload)
+        corrida = iniciar_corrida(session, CorridaStart(tipo_labirinto=TipoLabirinto.OITO, data_hora_inicio=datetime.now(UTC)))
         assert corrida.data_hora_inicio is not None
 
-
 class TestSalvarCorrida:
-    """CA: Sistema salva dados consolidados ao receber evento de encerramento."""
-
-    def _base(self, session: Session) -> Corrida:
-        return iniciar_corrida(
-            session,
-            CorridaStart(
-                tipo_labirinto=TipoLabirinto.QUATRO,
-                data_hora_inicio=datetime.now(UTC),
-            ),
-        )
+    def _base(self, session):
+        return iniciar_corrida(session, CorridaStart(tipo_labirinto=TipoLabirinto.QUATRO, data_hora_inicio=datetime.now(UTC)))
 
     def test_salva_campos_basicos(self, session: Session):
         corrida = self._base(session)
-        payload = CorridaSave(
-            tempo_total=5000,
-            velocidade_media=30.0,
-            velocidade_maxima_percurso=55.0,
-            status_corrida=StatusCorrida.CONCLUIDA,
-            desafio_cumprido=True,
-            data_hora_fim=datetime.now(UTC),
-        )
-        resultado = salvar_corrida(session, corrida.id_corrida, payload)
-
-        assert resultado.tempo_total == 5000
-        assert resultado.velocidade_media == 30.0
-        assert resultado.status_corrida == StatusCorrida.CONCLUIDA
-        assert resultado.desafio_cumprido is True
+        r = salvar_corrida(session, corrida.id_corrida, CorridaSave(tempo_total=5000, velocidade_media=30.0, velocidade_maxima_percurso=55.0, status_corrida=StatusCorrida.CONCLUIDA, desafio_cumprido=True, data_hora_fim=datetime.now(UTC)))
+        assert r.tempo_total == 5000 and r.velocidade_media == 30.0 and r.status_corrida == StatusCorrida.CONCLUIDA
 
     def test_salva_resultado_falha(self, session: Session):
-        """CA: Registra resultado do desafio (sucesso/falha)."""
         corrida = self._base(session)
-        payload = CorridaSave(
-            tempo_total=3000,
-            status_corrida=StatusCorrida.CONCLUIDA,
-            desafio_cumprido=False,
-        )
-        resultado = salvar_corrida(session, corrida.id_corrida, payload)
-
-        assert resultado.desafio_cumprido is False
-        assert resultado.status_corrida == StatusCorrida.CONCLUIDA
+        r = salvar_corrida(session, corrida.id_corrida, CorridaSave(tempo_total=3000, status_corrida=StatusCorrida.CONCLUIDA, desafio_cumprido=False))
+        assert r.desafio_cumprido is False
 
     def test_salva_percurso_via_celulas(self, session: Session):
-        """CA: Registra trajeto percorrido."""
         corrida = self._base(session)
         celulas = [
-            CelulaCreate(coordenada_x=0, coordenada_y=0,
-                         parede_norte=False, parede_sul=True,
-                         parede_leste=False, parede_oeste=True),
-            CelulaCreate(coordenada_x=1, coordenada_y=0,
-                         parede_norte=False, parede_sul=True,
-                         parede_leste=False, parede_oeste=False),
+            CelulaCreate(coordenada_x=0, coordenada_y=0, parede_norte=False, parede_sul=True, parede_leste=False, parede_oeste=True),
+            CelulaCreate(coordenada_x=1, coordenada_y=0, parede_norte=False, parede_sul=True, parede_leste=False, parede_oeste=False),
         ]
-        percurso = [
-            PercursoCreate(indice_celula=0, data_hora_passagem=datetime.now(UTC)),
-            PercursoCreate(indice_celula=1, data_hora_passagem=datetime.now(UTC)),
-        ]
-        payload = CorridaSave(
-            tempo_total=2000,
-            status_corrida=StatusCorrida.CONCLUIDA,
-            desafio_cumprido=True,
-            celulas=celulas,
-            percurso=percurso,
-        )
-        salvar_corrida(session, corrida.id_corrida, payload)
-
-        passos = session.exec(
-            select(Percurso).where(Percurso.id_corrida == corrida.id_corrida)
-        ).all()
-        assert len(passos) == 2
+        percurso = [PercursoCreate(indice_celula=0, data_hora_passagem=datetime.now(UTC)), PercursoCreate(indice_celula=1, data_hora_passagem=datetime.now(UTC))]
+        salvar_corrida(session, corrida.id_corrida, CorridaSave(tempo_total=2000, status_corrida=StatusCorrida.CONCLUIDA, desafio_cumprido=True, celulas=celulas, percurso=percurso))
+        assert len(session.exec(select(Percurso).where(Percurso.id_corrida == corrida.id_corrida)).all()) == 2
 
     def test_tempo_total_negativo_levanta_registro_error(self, session: Session):
-        """CA: Impede persistência quando campos obrigatórios estiverem inválidos."""
         corrida = self._base(session)
-        payload = CorridaSave(
-            tempo_total=-1,
-            status_corrida=StatusCorrida.CONCLUIDA,
-            desafio_cumprido=False,
-        )
         with pytest.raises(RegistroError):
-            salvar_corrida(session, corrida.id_corrida, payload)
+            salvar_corrida(session, corrida.id_corrida, CorridaSave(tempo_total=-1, status_corrida=StatusCorrida.CONCLUIDA, desafio_cumprido=False))
 
     def test_corrida_inexistente_levanta_registro_error(self, session: Session):
-        """CA: Impede persistência quando corrida não existe."""
-        payload = CorridaSave(
-            tempo_total=1000,
-            status_corrida=StatusCorrida.CONCLUIDA,
-            desafio_cumprido=True,
-        )
         with pytest.raises(RegistroError):
-            salvar_corrida(session, 999999, payload)
-
-
-# ---------------------------------------------------------------------------
-# Testes de persistência via fluxo de telemetria (endpoint HTTP)
-# ---------------------------------------------------------------------------
-
+            salvar_corrida(session, 999999, CorridaSave(tempo_total=1000, status_corrida=StatusCorrida.CONCLUIDA, desafio_cumprido=True))
 
 class TestPersistenciaFluxoTelemetria:
-    """Testa persistência end-to-end via endpoint POST /api/telemetria/pacote."""
-
-    def test_pacote_inicial_cria_corrida_no_banco(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Existe estrutura de banco / registra tipo do labirinto."""
+    def test_pacote_inicial_cria_corrida_no_banco(self, client: TestClient, session: Session):
         resp = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
         assert resp.status_code == 201
+        idb = resp.json()["estado"]["id_corrida_banco"]
+        corrida = session.get(Corrida, idb)
+        assert corrida is not None and corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
+        assert session.get(Labirinto, corrida.id_labirinto).tipo_labirinto == TipoLabirinto.QUATRO
 
-        id_corrida_banco = resp.json()["estado"]["id_corrida_banco"]
-        assert id_corrida_banco is not None
-
-        corrida = session.get(Corrida, id_corrida_banco)
-        assert corrida is not None
-        assert corrida.status_corrida == StatusCorrida.EM_ANDAMENTO
-        assert corrida.sessao_hardware_id == 42
-
-        labirinto = session.get(Labirinto, corrida.id_labirinto)
-        assert labirinto is not None
-        assert labirinto.tipo_labirinto == TipoLabirinto.QUATRO
-
-    def test_pacote_movimentacao_registra_percurso(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Sistema registra trajeto percorrido durante a execução."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
-
+    def test_pacote_movimentacao_registra_percurso(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
         client.post("/api/telemetria/pacote", json=PACOTE_MOV_1)
         client.post("/api/telemetria/pacote", json=PACOTE_MOV_2)
+        assert len(session.exec(select(Percurso).where(Percurso.id_corrida == idb)).all()) == 2
 
-        passos = session.exec(
-            select(Percurso).where(Percurso.id_corrida == id_corrida_banco)
-        ).all()
-        assert len(passos) == 2
-
-    def test_pacote_rota_registra_percurso_otimizado(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Sistema registra trajeto da rota otimizada."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
-
-        resp_rota = client.post("/api/telemetria/pacote", json=PACOTE_ROTA)
-        assert resp_rota.status_code == 201
-
-        passos = session.exec(
-            select(Percurso)
-            .where(Percurso.id_corrida == id_corrida_banco)
-            .order_by(Percurso.id_percurso)
-        ).all()
-
+    def test_pacote_rota_registra_percurso_otimizado(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
+        assert client.post("/api/telemetria/pacote", json=PACOTE_ROTA).status_code == 201
+        passos = session.exec(select(Percurso).where(Percurso.id_corrida == idb).order_by(Percurso.id_percurso)).all()
         assert len(passos) == 3
         for i, pt in enumerate(PACOTE_ROTA["rota"]):
-            assert passos[i].celula.coordenada_x == pt[0]
-            assert passos[i].celula.coordenada_y == pt[1]
+            assert passos[i].celula.coordenada_x == pt[0] and passos[i].celula.coordenada_y == pt[1]
             assert passos[i].tipo_percurso == "otimizado"
 
-    def test_percurso_reutiliza_celula_existente(
-        self, client: TestClient, session: Session
-    ):
-        """Robô que revisita posição não deve duplicar Célula, só Percurso."""
+    def test_percurso_reutiliza_celula_existente(self, client: TestClient, session: Session):
         client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        # Dois pacotes na mesma posição (x=1, y=0)
         client.post("/api/telemetria/pacote", json=PACOTE_MOV_1)
         client.post("/api/telemetria/pacote", json={**PACOTE_MOV_1, "timestamp_ms": 3000})
+        assert len(session.exec(select(Celula).where(Celula.coordenada_x == 1).where(Celula.coordenada_y == 0)).all()) == 1
 
-        celulas = session.exec(
-            select(Celula).where(Celula.coordenada_x == 1).where(Celula.coordenada_y == 0)
-        ).all()
-        # Apenas uma Célula para a posição (1, 0)
-        assert len(celulas) == 1
-
-    def test_pacote_final_salva_tempo_total(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Sistema registra tempo total da corrida."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
-
+    def test_pacote_final_salva_tempo_total(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
         client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
+        assert session.get(Corrida, idb).tempo_total == PACOTE_FINAL["timestamp_ms"]
 
-        corrida = session.get(Corrida, id_corrida_banco)
-        assert corrida.tempo_total == PACOTE_FINAL["timestamp_ms"]
-
-    def test_pacote_final_salva_resultado_desafio(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Sistema registra resultado do desafio (sucesso/falha)."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
-
+    def test_pacote_final_salva_resultado_desafio(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
         client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
+        c = session.get(Corrida, idb)
+        assert c.desafio_cumprido is True and c.status_corrida == StatusCorrida.CONCLUIDA
 
-        corrida = session.get(Corrida, id_corrida_banco)
-        assert corrida.desafio_cumprido is True
-        assert corrida.status_corrida == StatusCorrida.CONCLUIDA
+    def test_pacote_final_falha_salva_status_correto(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
+        client.post("/api/telemetria/pacote", json={**PACOTE_FINAL, "sucesso": False})
+        c = session.get(Corrida, idb)
+        assert c.desafio_cumprido is False and c.status_corrida == StatusCorrida.CONCLUIDA
 
-    def test_pacote_final_falha_salva_status_correto(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Resultado de falha registrado corretamente via desafio_cumprido."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
+    def test_pacote_invalido_nao_persiste(self, client: TestClient, session: Session):
+        assert client.post("/api/telemetria/pacote", json={"foo": "bar"}).status_code == 422
 
-        pacote_falha = {**PACOTE_FINAL, "sucesso": False}
-        client.post("/api/telemetria/pacote", json=pacote_falha)
-
-        corrida = session.get(Corrida, id_corrida_banco)
-        assert corrida.desafio_cumprido is False
-        # Status é sempre CONCLUIDA quando o pacote final é recebido
-        assert corrida.status_corrida == StatusCorrida.CONCLUIDA
-
-    def test_pacote_invalido_nao_persiste(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Impede persistência quando campos obrigatórios estão ausentes."""
-        # Pacote sem id_corrida e sem campos reconhecíveis
-        resp = client.post("/api/telemetria/pacote", json={"foo": "bar"})
-        assert resp.status_code == 422
-
-    def test_corrida_conclui_com_velocidade_media_do_firmware(
-        self, client: TestClient, session: Session
-    ):
-        """CA: Sistema registra dados de telemetria — velocidade média (do pacote final)."""
-        resp_ini = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
-        id_corrida_banco = resp_ini.json()["estado"]["id_corrida_banco"]
-
+    def test_corrida_conclui_com_velocidade_media_do_firmware(self, client: TestClient, session: Session):
+        idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]
         client.post("/api/telemetria/pacote", json=PACOTE_FINAL)
-
-        corrida = session.get(Corrida, id_corrida_banco)
-        assert corrida.velocidade_media == PACOTE_FINAL["v_med"]
+        assert session.get(Corrida, idb).velocidade_media == PACOTE_FINAL["v_med"]

--- a/src/backend/tests/test_telemetria.py
+++ b/src/backend/tests/test_telemetria.py
@@ -1,667 +1,307 @@
 """Testes unitários para a lógica dos indicadores de desempenho (telemetria).
 
-Cobre:
-  - Identificação de tipo de pacote
-  - Validação de pacotes (campos obrigatórios e regras por tipo)
-  - Cálculo de velocidade de segmento
-  - Atualização dos indicadores (função agregadora)
-  - Cenários simulados completos
+Pacotes seguem a especificação telemetria.md:
+  tipo 0 = Configuração Inicial
+  tipo 1 = Movimentação / Descoberta de Paredes
+  tipo 2 = Rota Otimizada
+  tipo 3 = Fim de Corrida
 """
-
 import math
-
 import pytest
 
 from app.schemas.telemetria import (
-    IndicadoresDesempenho,
-    StatusCorridaTelemetria,
-    TipoAlertaTelemetria,
-    TipoPacote,
+    IndicadoresDesempenho, StatusCorridaTelemetria, TipoAlertaTelemetria, TipoPacote,
 )
 from app.services.telemetria import (
-    BATERIA_CRITICA_THRESHOLD,
-    CELL_SIZE_CM,
-    PARADA_INESPERADA_THRESHOLD_MS,
-    atualizar_indicadores,
-    calcular_velocidade_segmento,
-    criar_estado_inicial,
-    identificar_tipo_pacote,
-    validar_pacote,
+    BATERIA_CRITICA_THRESHOLD, CELL_SIZE_CM, PARADA_INESPERADA_THRESHOLD_MS,
+    atualizar_indicadores, calcular_velocidade_segmento,
+    criar_estado_inicial, identificar_tipo_pacote, validar_pacote,
 )
 
-
 # ===================================================================
-# Dados mockados
+# Dados mockados — conforme telemetria.md
 # ===================================================================
 
-# Cenário 1 — Corrida normal
-PACOTE_INICIAL_NORMAL = {
-    "id_corrida": 1,
-    "timestamp_ms": 0,
-    "dimensao": 4,
-    "tentativa": 1,
-    "bateria": 95,
-}
+PACOTE_INICIAL_NORMAL = {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 95}
 
-PACOTES_MOVIMENTACAO_NORMAL = [
-    {"id_corrida": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
-    {"id_corrida": 1, "timestamp_ms": 2000, "x": 1, "y": 0, "w": 0},
-    {"id_corrida": 1, "timestamp_ms": 3000, "x": 1, "y": 1, "w": 90},
-    {"id_corrida": 1, "timestamp_ms": 4000, "x": 2, "y": 1, "w": 0},
-    {"id_corrida": 1, "timestamp_ms": 5000, "x": 2, "y": 2, "w": 90},
+PACOTE_MOVIMENTACAO = [
+    {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
+    {"tipo": 1, "timestamp_ms": 2000, "x": 1, "y": 0, "w": 0},
+    {"tipo": 1, "timestamp_ms": 3000, "x": 1, "y": 1, "w": 5},
+    {"tipo": 1, "timestamp_ms": 4000, "x": 2, "y": 1, "w": 0},
+    {"tipo": 1, "timestamp_ms": 5000, "x": 2, "y": 2, "w": 5},
 ]
 
-PACOTE_FINAL_SUCESSO = {
-    "id_corrida": 1,
-    "timestamp_ms": 30000,
-    "sucesso": True,
-    "v_med": 12.5,
-    "bateria": 80,
-}
+PACOTE_FINAL_SUCESSO = {"tipo": 3, "timestamp_ms": 30000, "sucesso": True, "v_med": 12.5, "bateria": 80}
 
-# Cenário 2 — Bateria crítica
-PACOTE_INICIAL_BATERIA_CRITICA = {
-    "id_corrida": 2,
-    "timestamp_ms": 0,
-    "dimensao": 4,
-    "tentativa": 1,
-    "bateria": 10,
-}
+PACOTE_INICIAL_BATERIA_CRITICA = {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 10}
 
-PACOTE_FINAL_BATERIA_CRITICA = {
-    "id_corrida": 2,
-    "timestamp_ms": 15000,
-    "sucesso": False,
-    "v_med": 5.0,
-    "bateria": 3,
-}
+PACOTE_FINAL_BATERIA_CRITICA = {"tipo": 3, "timestamp_ms": 15000, "sucesso": False, "v_med": 5.0, "bateria": 3}
 
-# Cenário 3 — Pacotes inválidos
-PACOTE_SEM_TIMESTAMP = {
-    "id_corrida": 1,
-    "dimensao": 4,
-    "tentativa": 1,
-    "bateria": 90,
-}
+PACOTE_SEM_TIMESTAMP = {"tipo": 0, "dimensao": 4, "bateria": 90}
+PACOTE_SEM_TIPO = {"timestamp_ms": 1000, "x": 1, "y": 1, "w": 0}
+PACOTE_MOV_SEM_X = {"tipo": 1, "timestamp_ms": 2000, "y": 1, "w": 0}
+PACOTE_FINAL_SEM_VMED = {"tipo": 3, "timestamp_ms": 30000, "sucesso": True, "bateria": 80}
+PACOTE_TIMESTAMP_REGRESSIVO = {"tipo": 1, "timestamp_ms": 500, "x": 3, "y": 3, "w": 5}
 
-PACOTE_SEM_ID_CORRIDA = {
-    "timestamp_ms": 1000,
-    "x": 1,
-    "y": 1,
-    "w": 0,
-}
-
-PACOTE_MOV_SEM_X = {
-    "id_corrida": 1,
-    "timestamp_ms": 2000,
-    "y": 1,
-    "w": 0,
-}
-
-PACOTE_FINAL_SEM_VMED = {
-    "id_corrida": 1,
-    "timestamp_ms": 30000,
-    "sucesso": True,
-    "bateria": 80,
-}
-
-# Cenário 4 — Timestamp inconsistente
-PACOTE_TIMESTAMP_REGRESSIVO = {
-    "id_corrida": 1,
-    "timestamp_ms": 500,
-    "x": 3,
-    "y": 3,
-    "w": 180,
-}
-
-PACOTES_MOVIMENTACAO_PARADA = [
-    {"id_corrida": 3, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
-    {"id_corrida": 3, "timestamp_ms": 2500, "x": 0, "y": 0, "w": 0},
-    {"id_corrida": 3, "timestamp_ms": 4501, "x": 0, "y": 0, "w": 0},
+PACOTE_MOVIMENTACAO_PARADA = [
+    {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0},
+    {"tipo": 1, "timestamp_ms": 2500, "x": 0, "y": 0, "w": 0},
+    {"tipo": 1, "timestamp_ms": 4501, "x": 0, "y": 0, "w": 0},
 ]
-
-
-# ===================================================================
-# Testes — Identificação de tipo de pacote
-# ===================================================================
 
 
 class TestIdentificarTipoPacote:
-    """Testes para identificar_tipo_pacote()."""
-
     def test_pacote_inicial(self):
         assert identificar_tipo_pacote(PACOTE_INICIAL_NORMAL) == TipoPacote.INICIAL
-
     def test_pacote_movimentacao(self):
-        assert (
-            identificar_tipo_pacote(PACOTES_MOVIMENTACAO_NORMAL[0])
-            == TipoPacote.MOVIMENTACAO
-        )
-
+        assert identificar_tipo_pacote(PACOTE_MOVIMENTACAO[0]) == TipoPacote.MOVIMENTACAO
     def test_pacote_final(self):
         assert identificar_tipo_pacote(PACOTE_FINAL_SUCESSO) == TipoPacote.FINAL
-
+    def test_pacote_rota(self):
+        assert identificar_tipo_pacote({"tipo": 2, "timestamp_ms": 0, "rota": []}) == TipoPacote.ROTA
     def test_pacote_invalido_dict_vazio(self):
         assert identificar_tipo_pacote({}) == TipoPacote.INVALIDO
-
     def test_pacote_invalido_none(self):
         assert identificar_tipo_pacote(None) == TipoPacote.INVALIDO
-
     def test_pacote_invalido_tipo_errado(self):
         assert identificar_tipo_pacote("not a dict") == TipoPacote.INVALIDO
-
-    def test_pacote_invalido_campos_parciais(self):
-        assert identificar_tipo_pacote({"x": 1, "y": 2}) == TipoPacote.INVALIDO
-
-    def test_pacote_final_sem_vmed_nao_e_final(self):
-        """Pacote com 'sucesso' e 'bateria' mas sem 'v_med' não é final."""
-        assert identificar_tipo_pacote(PACOTE_FINAL_SEM_VMED) == TipoPacote.INVALIDO
-
-
-# ===================================================================
-# Testes — Validação de pacotes
-# ===================================================================
+    def test_pacote_invalido_tipo_desconhecido(self):
+        assert identificar_tipo_pacote({"tipo": 99}) == TipoPacote.INVALIDO
+    def test_pacote_sem_campo_tipo(self):
+        assert identificar_tipo_pacote(PACOTE_SEM_TIPO) == TipoPacote.INVALIDO
+    def test_pacote_tipo_string_invalido(self):
+        assert identificar_tipo_pacote({"tipo": "inicial"}) == TipoPacote.INVALIDO
 
 
 class TestValidarPacote:
-    """Testes para validar_pacote()."""
-
     def test_pacote_inicial_valido(self):
         result = validar_pacote(PACOTE_INICIAL_NORMAL, TipoPacote.INICIAL)
-        assert result.valido is True
-        assert result.erros == []
-
+        assert result.valido is True and result.erros == []
     def test_pacote_movimentacao_valido(self):
-        result = validar_pacote(
-            PACOTES_MOVIMENTACAO_NORMAL[1], TipoPacote.MOVIMENTACAO, 1000
-        )
-        assert result.valido is True
-
+        assert validar_pacote(PACOTE_MOVIMENTACAO[1], TipoPacote.MOVIMENTACAO, 1000).valido
     def test_pacote_final_valido(self):
-        result = validar_pacote(PACOTE_FINAL_SUCESSO, TipoPacote.FINAL)
-        assert result.valido is True
-
+        assert validar_pacote(PACOTE_FINAL_SUCESSO, TipoPacote.FINAL).valido
     def test_tipo_invalido_rejeita(self):
-        result = validar_pacote({}, TipoPacote.INVALIDO)
-        assert result.valido is False
-        assert "Tipo de pacote não reconhecido." in result.erros
-
-    def test_sem_id_corrida(self):
-        result = validar_pacote(PACOTE_SEM_ID_CORRIDA, TipoPacote.MOVIMENTACAO)
-        assert result.valido is False
-        assert any("id_corrida" in e for e in result.erros)
-
+        r = validar_pacote({}, TipoPacote.INVALIDO)
+        assert not r.valido and "Tipo de pacote não reconhecido." in r.erros
+    def test_sem_tipo(self):
+        assert not validar_pacote(PACOTE_SEM_TIPO, TipoPacote.INVALIDO).valido
     def test_sem_timestamp(self):
-        result = validar_pacote(PACOTE_SEM_TIMESTAMP, TipoPacote.INICIAL)
-        assert result.valido is False
-        assert any("timestamp_ms" in e for e in result.erros)
-
+        r = validar_pacote(PACOTE_SEM_TIMESTAMP, TipoPacote.INICIAL)
+        assert not r.valido and any("timestamp_ms" in e for e in r.erros)
     def test_timestamp_negativo(self):
-        pacote = {**PACOTE_INICIAL_NORMAL, "timestamp_ms": -1}
-        result = validar_pacote(pacote, TipoPacote.INICIAL)
-        assert result.valido is False
-        assert any("negativo" in e for e in result.erros)
-
+        r = validar_pacote({**PACOTE_INICIAL_NORMAL, "timestamp_ms": -1}, TipoPacote.INICIAL)
+        assert not r.valido and any("negativo" in e for e in r.erros)
     def test_timestamp_regressivo(self):
-        result = validar_pacote(
-            PACOTE_TIMESTAMP_REGRESSIVO,
-            TipoPacote.MOVIMENTACAO,
-            ultimo_timestamp_ms=5000,
-        )
-        assert result.valido is False
-        assert any("regressivo" in e.lower() for e in result.erros)
-
+        r = validar_pacote(PACOTE_TIMESTAMP_REGRESSIVO, TipoPacote.MOVIMENTACAO, ultimo_timestamp_ms=5000)
+        assert not r.valido and any("regressivo" in e.lower() for e in r.erros)
     def test_bateria_fora_de_range_inicial(self):
-        pacote = {**PACOTE_INICIAL_NORMAL, "bateria": 150}
-        result = validar_pacote(pacote, TipoPacote.INICIAL)
-        assert result.valido is False
-        assert any("Bateria" in e for e in result.erros)
-
+        r = validar_pacote({**PACOTE_INICIAL_NORMAL, "bateria": 150}, TipoPacote.INICIAL)
+        assert not r.valido and any("Bateria" in e for e in r.erros)
     def test_bateria_negativa_final(self):
-        pacote = {**PACOTE_FINAL_SUCESSO, "bateria": -5}
-        result = validar_pacote(pacote, TipoPacote.FINAL)
-        assert result.valido is False
-
+        assert not validar_pacote({**PACOTE_FINAL_SUCESSO, "bateria": -5}, TipoPacote.FINAL).valido
     def test_movimentacao_sem_x(self):
-        result = validar_pacote(PACOTE_MOV_SEM_X, TipoPacote.MOVIMENTACAO)
-        assert result.valido is False
-        assert any("'x'" in e for e in result.erros)
-
+        r = validar_pacote(PACOTE_MOV_SEM_X, TipoPacote.MOVIMENTACAO)
+        assert not r.valido and any("'x'" in e for e in r.erros)
     def test_final_sem_vmed(self):
-        pacote = {
-            "id_corrida": 1,
-            "timestamp_ms": 30000,
-            "sucesso": True,
-            "bateria": 80,
-        }
-        result = validar_pacote(pacote, TipoPacote.FINAL)
-        assert result.valido is False
-        assert any("v_med" in e for e in result.erros)
-
+        r = validar_pacote(PACOTE_FINAL_SEM_VMED, TipoPacote.FINAL)
+        assert not r.valido and any("v_med" in e for e in r.erros)
     def test_final_vmed_negativo(self):
-        pacote = {**PACOTE_FINAL_SUCESSO, "v_med": -3.0}
-        result = validar_pacote(pacote, TipoPacote.FINAL)
-        assert result.valido is False
-        assert any("v_med" in e for e in result.erros)
-
+        r = validar_pacote({**PACOTE_FINAL_SUCESSO, "v_med": -3.0}, TipoPacote.FINAL)
+        assert not r.valido and any("v_med" in e for e in r.erros)
     def test_final_sucesso_nao_booleano(self):
-        pacote = {**PACOTE_FINAL_SUCESSO, "sucesso": "sim"}
-        result = validar_pacote(pacote, TipoPacote.FINAL)
-        assert result.valido is False
-        assert any("sucesso" in e for e in result.erros)
-
-
-# ===================================================================
-# Testes — Cálculo de velocidade de segmento
-# ===================================================================
+        r = validar_pacote({**PACOTE_FINAL_SUCESSO, "sucesso": "sim"}, TipoPacote.FINAL)
+        assert not r.valido and any("sucesso" in e for e in r.erros)
+    def test_w_fora_do_range(self):
+        r = validar_pacote({"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 16}, TipoPacote.MOVIMENTACAO)
+        assert not r.valido and any("w" in e for e in r.erros)
+    def test_w_float_rejeitado(self):
+        r = validar_pacote({"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 5.5}, TipoPacote.MOVIMENTACAO)
+        assert not r.valido and any("'w'" in e for e in r.erros)
+    def test_dimensao_invalida(self):
+        r = validar_pacote({**PACOTE_INICIAL_NORMAL, "dimensao": 5}, TipoPacote.INICIAL)
+        assert not r.valido and any("Dimensão" in e for e in r.erros)
 
 
 class TestCalcularVelocidadeSegmento:
-    """Testes para calcular_velocidade_segmento()."""
-
     def test_velocidade_basica(self):
-        # 1 célula em 1 segundo = CELL_SIZE_CM cm/s
-        vel = calcular_velocidade_segmento(0, 0, 0, 1, 0, 1000)
-        assert vel == pytest.approx(CELL_SIZE_CM, rel=1e-6)
-
+        assert calcular_velocidade_segmento(0, 0, 0, 1, 0, 1000) == pytest.approx(CELL_SIZE_CM, rel=1e-6)
     def test_velocidade_diagonal(self):
-        # diagonal de 1 célula = sqrt(2) * CELL_SIZE_CM em 1 segundo
-        vel = calcular_velocidade_segmento(0, 0, 0, 1, 1, 1000)
-        expected = math.sqrt(2) * CELL_SIZE_CM
-        assert vel == pytest.approx(expected, rel=1e-6)
-
+        assert calcular_velocidade_segmento(0, 0, 0, 1, 1, 1000) == pytest.approx(math.sqrt(2) * CELL_SIZE_CM, rel=1e-6)
     def test_delta_t_zero_retorna_none(self):
         assert calcular_velocidade_segmento(0, 0, 1000, 1, 0, 1000) is None
-
     def test_delta_t_negativo_retorna_none(self):
         assert calcular_velocidade_segmento(0, 0, 2000, 1, 0, 1000) is None
-
     def test_sem_deslocamento(self):
-        vel = calcular_velocidade_segmento(1, 1, 0, 1, 1, 1000)
-        assert vel == pytest.approx(0.0)
-
+        assert calcular_velocidade_segmento(1, 1, 0, 1, 1, 1000) == pytest.approx(0.0)
     def test_velocidade_nunca_negativa(self):
         vel = calcular_velocidade_segmento(0, 0, 0, 0, 0, 1000)
-        assert vel is not None
-        assert vel >= 0
-
-
-# ===================================================================
-# Testes — Estado inicial
-# ===================================================================
+        assert vel is not None and vel >= 0
 
 
 class TestCriarEstadoInicial:
-    """Testes para criar_estado_inicial()."""
-
     def test_estado_aguardando(self):
-        estado = criar_estado_inicial()
-        assert estado.status_corrida == StatusCorridaTelemetria.AGUARDANDO
-
+        assert criar_estado_inicial().status_corrida == StatusCorridaTelemetria.AGUARDANDO
     def test_campos_zerados(self):
-        estado = criar_estado_inicial()
-        assert estado.id_corrida_banco is None
-        assert estado.sessao_hardware_id is None
-        assert estado.bateria_atual is None
-        assert estado.velocidade_media is None
-        assert estado.tempo_decorrido_ms == 0
-        assert estado.tempo_final_ms is None
-        assert estado.alerta_bateria_critica is False
-        assert estado.alerta_possivel_parada_inesperada is False
-        assert estado.alerta_dado_invalido is False
-        assert estado.log_alertas == []
-
-
-# ===================================================================
-# Testes — Função agregadora (atualizar_indicadores)
-# ===================================================================
+        e = criar_estado_inicial()
+        assert e.id_corrida_banco is None and e.bateria_atual is None
+        assert e.velocidade_media is None and e.tempo_decorrido_ms == 0
+        assert not e.alerta_bateria_critica and e.log_alertas == []
 
 
 class TestAtualizarIndicadores:
-    """Testes para atualizar_indicadores()."""
-
     def test_pacote_inicial_atualiza_bateria(self):
-        estado = criar_estado_inicial()
-        novo = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        assert novo.bateria_atual == 95
-        assert novo.status_corrida == StatusCorridaTelemetria.EM_ANDAMENTO
-
-    def test_pacote_inicial_seta_sessao_hardware_id(self):
-        estado = criar_estado_inicial()
-        novo = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        assert novo.sessao_hardware_id == 1
+        novo = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        assert novo.bateria_atual == 95 and novo.status_corrida == StatusCorridaTelemetria.EM_ANDAMENTO
 
     def test_pacote_movimentacao_atualiza_tempo(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[0])
-        assert estado.tempo_decorrido_ms == 1000
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[0])
+        assert e.tempo_decorrido_ms == 1000
 
     def test_pacote_movimentacao_atualiza_velocidade_media(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        # Primeiro pacote de mov: seta posição inicial, sem cálculo de vel
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[0])
-        # Segundo pacote de mov: deslocamento de (0,0) para (1,0) em 1s
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[1])
-        assert estado.velocidade_media is not None
-        assert estado.velocidade_media == pytest.approx(CELL_SIZE_CM, rel=1e-6)
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[0])
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[1])
+        assert e.velocidade_media is not None and e.velocidade_media == pytest.approx(CELL_SIZE_CM, rel=1e-6)
 
     def test_pacote_invalido_nao_altera_indicadores(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        bateria_antes = estado.bateria_atual
-        tempo_antes = estado.tempo_decorrido_ms
-
-        # Enviar pacote inválido
-        estado_apos = atualizar_indicadores(estado, {"campo_errado": 42})
-        assert estado_apos.bateria_atual == bateria_antes
-        assert estado_apos.tempo_decorrido_ms == tempo_antes
-        assert estado_apos.alerta_dado_invalido is True
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        bat, t = e.bateria_atual, e.tempo_decorrido_ms
+        e2 = atualizar_indicadores(e, {"campo_errado": 42})
+        assert e2.bateria_atual == bat and e2.tempo_decorrido_ms == t and e2.alerta_dado_invalido
 
     def test_pacote_none_nao_altera_indicadores(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado_apos = atualizar_indicadores(estado, None)
-        assert estado_apos.alerta_dado_invalido is True
-        assert estado_apos.bateria_atual == 95
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e2 = atualizar_indicadores(e, None)
+        assert e2.alerta_dado_invalido and e2.bateria_atual == 95
 
     def test_timestamp_regressivo_ignorado(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[0])
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[1])
-
-        tempo_antes = estado.tempo_decorrido_ms
-        # Pacote com timestamp menor que o último válido
-        estado_apos = atualizar_indicadores(estado, PACOTE_TIMESTAMP_REGRESSIVO)
-        assert estado_apos.tempo_decorrido_ms == tempo_antes
-        assert estado_apos.alerta_dado_invalido is True
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[0])
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[1])
+        t = e.tempo_decorrido_ms
+        e2 = atualizar_indicadores(e, PACOTE_TIMESTAMP_REGRESSIVO)
+        assert e2.tempo_decorrido_ms == t and e2.alerta_dado_invalido
 
     def test_pacote_final_fixa_tempo_final(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        for mov in PACOTES_MOVIMENTACAO_NORMAL:
-            estado = atualizar_indicadores(estado, mov)
-
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_SUCESSO)
-        assert estado.tempo_final_ms == 30000
-        assert estado.tempo_decorrido_ms == 30000
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        for m in PACOTE_MOVIMENTACAO:
+            e = atualizar_indicadores(e, m)
+        e = atualizar_indicadores(e, PACOTE_FINAL_SUCESSO)
+        assert e.tempo_final_ms == 30000 and e.tempo_decorrido_ms == 30000
 
     def test_pacote_final_usa_vmed_como_velocidade_final(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        for mov in PACOTES_MOVIMENTACAO_NORMAL:
-            estado = atualizar_indicadores(estado, mov)
-
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_SUCESSO)
-        assert estado.velocidade_media == 12.5
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        for m in PACOTE_MOVIMENTACAO:
+            e = atualizar_indicadores(e, m)
+        e = atualizar_indicadores(e, PACOTE_FINAL_SUCESSO)
+        assert e.velocidade_media == 12.5
 
     def test_pacote_final_atualiza_status_concluida(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_SUCESSO)
-        assert estado.status_corrida == StatusCorridaTelemetria.CONCLUIDA
-        assert estado.sucesso is True
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_FINAL_SUCESSO)
+        assert e.status_corrida == StatusCorridaTelemetria.CONCLUIDA and e.sucesso is True
 
     def test_pacote_final_falha(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_BATERIA_CRITICA)
-        assert estado.status_corrida == StatusCorridaTelemetria.FALHA
-        assert estado.sucesso is False
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_FINAL_BATERIA_CRITICA)
+        assert e.status_corrida == StatusCorridaTelemetria.FALHA and e.sucesso is False
 
     def test_bateria_critica_ativa_alerta(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_BATERIA_CRITICA)
-        assert estado.alerta_bateria_critica is True
-        assert estado.bateria_atual == 10
-        assert estado.log_alertas[-1].tipo == TipoAlertaTelemetria.BATERIA_CRITICA
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_BATERIA_CRITICA)
+        assert e.alerta_bateria_critica and e.bateria_atual == 10
+        assert e.log_alertas[-1].tipo == TipoAlertaTelemetria.BATERIA_CRITICA
 
     def test_bateria_normal_nao_ativa_alerta(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        assert estado.alerta_bateria_critica is False
+        assert not atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL).alerta_bateria_critica
 
     def test_bateria_critica_exige_threshold_inclusivo(self):
         assert BATERIA_CRITICA_THRESHOLD == 10.0
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_BATERIA_CRITICA)
-        assert estado.alerta_bateria_critica is True
+        assert atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_BATERIA_CRITICA).alerta_bateria_critica
 
     def test_alertas_nao_mutam_estado_original(self):
-        estado = criar_estado_inicial()
-        novo_estado = atualizar_indicadores(estado, PACOTE_INICIAL_BATERIA_CRITICA)
-        assert estado.log_alertas == []
-        assert len(novo_estado.log_alertas) == 1
+        e = criar_estado_inicial()
+        novo = atualizar_indicadores(e, PACOTE_INICIAL_BATERIA_CRITICA)
+        assert e.log_alertas == [] and len(novo.log_alertas) == 1
 
     def test_bateria_critica_nao_duplica_log_enquanto_persistir(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_BATERIA_CRITICA)
-        total_alertas = len(estado.log_alertas)
-
-        estado = atualizar_indicadores(
-            estado,
-            {
-                "id_corrida": 2,
-                "timestamp_ms": 1000,
-                "x": 0,
-                "y": 0,
-                "w": 0,
-                "bateria": 9,
-            },
-        )
-        assert len(estado.log_alertas) == total_alertas
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_BATERIA_CRITICA)
+        n = len(e.log_alertas)
+        e = atualizar_indicadores(e, {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0})
+        assert len(e.log_alertas) == n
 
     def test_bateria_critica_no_pacote_final(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_BATERIA_CRITICA)
-        assert estado.alerta_bateria_critica is True
-        assert estado.bateria_atual == 3
-
-    def test_movimentacao_com_bateria_atualiza(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-
-        pacote_mov_com_bateria = {
-            **PACOTES_MOVIMENTACAO_NORMAL[0],
-            "bateria": 88,
-        }
-        estado = atualizar_indicadores(estado, pacote_mov_com_bateria)
-        assert estado.bateria_atual == 88
-
-    def test_movimentacao_sem_bateria_mantem_ultima(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        # Movimentação sem campo bateria
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[0])
-        assert estado.bateria_atual == 95  # mantém do pacote inicial
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_FINAL_BATERIA_CRITICA)
+        assert e.alerta_bateria_critica and e.bateria_atual == 3
 
     def test_parada_inesperada_dispara_apos_mais_de_tres_segundos(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(
-            estado,
-            {
-                "id_corrida": 3,
-                "timestamp_ms": 0,
-                "dimensao": 4,
-                "tentativa": 1,
-                "bateria": 85,
-            },
-        )
-
-        for pacote in PACOTES_MOVIMENTACAO_PARADA:
-            estado = atualizar_indicadores(estado, pacote)
-
-        assert PARADA_INESPERADA_THRESHOLD_MS == 3000
-        assert estado.alerta_possivel_parada_inesperada is True
-        assert estado.log_alertas[-1].tipo == (
-            TipoAlertaTelemetria.POSSIVEL_PARADA_INESPERADA
-        )
-        assert estado.log_alertas[-1].timestamp_ms == 4501
+        e = atualizar_indicadores(criar_estado_inicial(), {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+        for p in PACOTE_MOVIMENTACAO_PARADA:
+            e = atualizar_indicadores(e, p)
+        assert e.alerta_possivel_parada_inesperada
+        assert e.log_alertas[-1].tipo == TipoAlertaTelemetria.POSSIVEL_PARADA_INESPERADA
 
     def test_parada_inesperada_nao_dispara_com_tres_segundos_exatos(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(
-            estado,
-            {
-                "id_corrida": 3,
-                "timestamp_ms": 0,
-                "dimensao": 4,
-                "tentativa": 1,
-                "bateria": 85,
-            },
-        )
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_PARADA[0])
-        estado = atualizar_indicadores(
-            estado,
-            {"id_corrida": 3, "timestamp_ms": 4000, "x": 0, "y": 0, "w": 0},
-        )
-        assert estado.alerta_possivel_parada_inesperada is False
+        e = atualizar_indicadores(criar_estado_inicial(), {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO_PARADA[0])
+        e = atualizar_indicadores(e, {"tipo": 1, "timestamp_ms": 4000, "x": 0, "y": 0, "w": 0})
+        assert not e.alerta_possivel_parada_inesperada
 
     def test_parada_inesperada_nao_dispara_quando_corrida_nao_esta_ativa(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado.status_corrida = StatusCorridaTelemetria.CONCLUIDA
-
-        for pacote in (
-            PACOTES_MOVIMENTACAO_PARADA[0],
-            {"id_corrida": 1, "timestamp_ms": 5000, "x": 0, "y": 0, "w": 0},
-        ):
-            estado = atualizar_indicadores(estado, pacote)
-
-        assert estado.alerta_possivel_parada_inesperada is False
-        assert not any(
-            alerta.tipo == TipoAlertaTelemetria.POSSIVEL_PARADA_INESPERADA
-            for alerta in estado.log_alertas
-        )
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e.status_corrida = StatusCorridaTelemetria.CONCLUIDA
+        for p in (PACOTE_MOVIMENTACAO_PARADA[0], {"tipo": 1, "timestamp_ms": 5000, "x": 0, "y": 0, "w": 0}):
+            e = atualizar_indicadores(e, p)
+        assert not e.alerta_possivel_parada_inesperada
 
     def test_parada_inesperada_e_limpa_ao_encerrar_corrida(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(
-            estado,
-            {
-                "id_corrida": 3,
-                "timestamp_ms": 0,
-                "dimensao": 4,
-                "tentativa": 1,
-                "bateria": 85,
-            },
-        )
-        for pacote in PACOTES_MOVIMENTACAO_PARADA:
-            estado = atualizar_indicadores(estado, pacote)
-
-        assert estado.alerta_possivel_parada_inesperada is True
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_SUCESSO)
-        assert estado.alerta_possivel_parada_inesperada is False
-
-
-# ===================================================================
-# Testes — Cenários simulados completos
-# ===================================================================
+        e = atualizar_indicadores(criar_estado_inicial(), {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+        for p in PACOTE_MOVIMENTACAO_PARADA:
+            e = atualizar_indicadores(e, p)
+        assert e.alerta_possivel_parada_inesperada
+        e = atualizar_indicadores(e, PACOTE_FINAL_SUCESSO)
+        assert not e.alerta_possivel_parada_inesperada
 
 
 class TestCenariosSimulados:
-    """Testes de integração com sequências completas de pacotes."""
-
     def test_corrida_normal_completa(self):
-        """Cenário 1: pacote inicial → movimentações → pacote final com sucesso."""
-        estado = criar_estado_inicial()
-
-        # Início
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        assert estado.status_corrida == StatusCorridaTelemetria.EM_ANDAMENTO
-        assert estado.bateria_atual == 95
-
-        # Movimentações
-        for mov in PACOTES_MOVIMENTACAO_NORMAL:
-            estado = atualizar_indicadores(estado, mov)
-
-        assert estado.tempo_decorrido_ms == 5000
-        assert estado.velocidade_media is not None
-        assert estado.velocidade_media > 0
-
-        # Final
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_SUCESSO)
-        assert estado.status_corrida == StatusCorridaTelemetria.CONCLUIDA
-        assert estado.sucesso is True
-        assert estado.tempo_final_ms == 30000
-        assert estado.velocidade_media == 12.5
-        assert estado.bateria_atual == 80
-        assert estado.alerta_bateria_critica is False
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        for m in PACOTE_MOVIMENTACAO:
+            e = atualizar_indicadores(e, m)
+        e = atualizar_indicadores(e, PACOTE_FINAL_SUCESSO)
+        assert e.status_corrida == StatusCorridaTelemetria.CONCLUIDA
+        assert e.sucesso and e.tempo_final_ms == 30000 and e.velocidade_media == 12.5
 
     def test_corrida_com_bateria_critica(self):
-        """Cenário 2: bateria crítica desde o início."""
-        estado = criar_estado_inicial()
-
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_BATERIA_CRITICA)
-        assert estado.alerta_bateria_critica is True
-
-        estado = atualizar_indicadores(estado, PACOTE_FINAL_BATERIA_CRITICA)
-        assert estado.alerta_bateria_critica is True
-        assert estado.bateria_atual == 3
-        assert estado.status_corrida == StatusCorridaTelemetria.FALHA
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_BATERIA_CRITICA)
+        e = atualizar_indicadores(e, PACOTE_FINAL_BATERIA_CRITICA)
+        assert e.alerta_bateria_critica and e.bateria_atual == 3 and e.status_corrida == StatusCorridaTelemetria.FALHA
 
     def test_corrida_com_parada_inesperada_registra_log(self):
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(
-            estado,
-            {
-                "id_corrida": 3,
-                "timestamp_ms": 0,
-                "dimensao": 4,
-                "tentativa": 1,
-                "bateria": 85,
-            },
-        )
-
-        for pacote in PACOTES_MOVIMENTACAO_PARADA:
-            estado = atualizar_indicadores(estado, pacote)
-
-        assert estado.alerta_possivel_parada_inesperada is True
-        assert estado.log_alertas[-1].tipo == (
-            TipoAlertaTelemetria.POSSIVEL_PARADA_INESPERADA
-        )
+        e = atualizar_indicadores(criar_estado_inicial(), {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 85})
+        for p in PACOTE_MOVIMENTACAO_PARADA:
+            e = atualizar_indicadores(e, p)
+        assert e.alerta_possivel_parada_inesperada
+        assert e.log_alertas[-1].tipo == TipoAlertaTelemetria.POSSIVEL_PARADA_INESPERADA
 
     def test_corrida_com_pacotes_invalidos(self):
-        """Cenário 3: pacotes inválidos intercalados não afetam o estado."""
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-
-        # Pacote inválido sem timestamp
-        estado_temp = atualizar_indicadores(estado, PACOTE_SEM_TIMESTAMP)
-        assert estado_temp.alerta_dado_invalido is True
-        assert estado_temp.tempo_decorrido_ms == estado.tempo_decorrido_ms
-
-        # Pacote inválido sem id_corrida
-        estado_temp = atualizar_indicadores(estado, PACOTE_SEM_ID_CORRIDA)
-        assert estado_temp.alerta_dado_invalido is True
-
-        # Pacote inválido de mov sem x
-        estado_temp = atualizar_indicadores(estado, PACOTE_MOV_SEM_X)
-        assert estado_temp.alerta_dado_invalido is True
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        for bad in (PACOTE_SEM_TIMESTAMP, PACOTE_SEM_TIPO, PACOTE_MOV_SEM_X):
+            e2 = atualizar_indicadores(e, bad)
+            assert e2.alerta_dado_invalido
 
     def test_corrida_com_timestamp_inconsistente(self):
-        """Cenário 4: timestamp regressivo é rejeitado."""
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[0])  # ts=1000
-        estado = atualizar_indicadores(estado, PACOTES_MOVIMENTACAO_NORMAL[1])  # ts=2000
-
-        # Timestamp regressivo (500 < 2000)
-        estado_apos = atualizar_indicadores(estado, PACOTE_TIMESTAMP_REGRESSIVO)
-        assert estado_apos.alerta_dado_invalido is True
-        assert estado_apos.tempo_decorrido_ms == 2000  # não atualizou
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[0])
+        e = atualizar_indicadores(e, PACOTE_MOVIMENTACAO[1])
+        e2 = atualizar_indicadores(e, PACOTE_TIMESTAMP_REGRESSIVO)
+        assert e2.alerta_dado_invalido and e2.tempo_decorrido_ms == 2000
 
     def test_estado_nao_mutado_por_pacote_invalido(self):
-        """Garante que o estado original não é mutado pela função."""
-        estado = criar_estado_inicial()
-        estado = atualizar_indicadores(estado, PACOTE_INICIAL_NORMAL)
-
-        estado_congelado = estado.model_copy()
-        _ = atualizar_indicadores(estado, {"invalido": True})
-
-        # Estado original deve estar intacto
-        assert estado.bateria_atual == estado_congelado.bateria_atual
-        assert estado.tempo_decorrido_ms == estado_congelado.tempo_decorrido_ms
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL_NORMAL)
+        ec = e.model_copy()
+        _ = atualizar_indicadores(e, {"invalido": True})
+        assert e.bateria_atual == ec.bateria_atual and e.tempo_decorrido_ms == ec.tempo_decorrido_ms

--- a/src/backend/tests/test_telemetria_router.py
+++ b/src/backend/tests/test_telemetria_router.py
@@ -2,108 +2,41 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 from app.models.corrida import Corrida
-from app.models.evento import Evento
-
-# ---------------------------------------------------------------------------
-# CAMINHO FELIZ
-# ---------------------------------------------------------------------------
 
 def test_fluxo_telemetria_completo_sucesso(client: TestClient, session: Session):
-    """Garante que o ciclo completo de uma corrida funciona e persiste no banco."""
-    id_hw = 999
-    
-    # 1. Pacote Inicial
-    resp_init = client.post("/api/telemetria/pacote", json={
-        "id_corrida": id_hw, "timestamp_ms": 100, "dimensao": 16, "tentativa": 1, "bateria": 100.0
-    })
+    resp_init = client.post("/api/telemetria/pacote", json={"tipo": 0, "timestamp_ms": 100, "dimensao": 16, "bateria": 100})
     assert resp_init.status_code == 201
-    
-    # 2. Pacote Movimentação
-    resp_mov = client.post("/api/telemetria/pacote", json={
-        "id_corrida": id_hw, "timestamp_ms": 2000, "x": 1.5, "y": 2.0, "w": 90.0
-    })
+    resp_mov = client.post("/api/telemetria/pacote", json={"tipo": 1, "timestamp_ms": 2000, "x": 1, "y": 2, "w": 5})
     assert resp_mov.status_code == 201
-    
-    # 3. Pacote Final
-    resp_end = client.post("/api/telemetria/pacote", json={
-        "id_corrida": id_hw, "timestamp_ms": 5000, "sucesso": True, "v_med": 20.0, "bateria": 95.0
-    })
+    resp_end = client.post("/api/telemetria/pacote", json={"tipo": 3, "timestamp_ms": 5000, "sucesso": True, "v_med": 20.0, "bateria": 95})
     assert resp_end.status_code == 201
-    
-    # Verificações no Banco de Dados
-    corrida = session.exec(select(Corrida).where(Corrida.sessao_hardware_id == id_hw)).first()
-    assert corrida is not None
-    assert corrida.bateria_inicial == 100.0
-    assert corrida.bateria_final == 95.0
-    assert corrida.desafio_cumprido is True
-
-# ---------------------------------------------------------------------------
-# CENÁRIOS DE FALHA (HTTP 422) - PARAMETRIZADO
-# ---------------------------------------------------------------------------
+    id_corrida_banco = resp_init.json()["estado"]["id_corrida_banco"]
+    corrida = session.get(Corrida, id_corrida_banco)
+    assert corrida is not None and corrida.bateria_inicial == 100 and corrida.desafio_cumprido is True
 
 @pytest.mark.parametrize("nome_caso, payload, erro_esperado", [
-    # Regras Gerais
-    ("Falta id_corrida", 
-     {"timestamp_ms": 100, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
-     "Campo 'id_corrida' ausente."),
-    
-    ("id_corrida não inteiro", 
-     {"id_corrida": "abc", "timestamp_ms": 100, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
-     "Campo 'id_corrida' deve ser um número inteiro (recebido: abc)."),
-    
-    ("Timestamp negativo", 
-     {"id_corrida": 1, "timestamp_ms": -10, "dimensao": 4, "tentativa": 1, "bateria": 90}, 
-     "Campo 'timestamp_ms' não pode ser negativo (recebido: -10)."),
-
-    # Pacote Inicial
-    ("Dimensão inválida (5)", 
-     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 5, "tentativa": 1, "bateria": 90}, 
-     "Dimensão inválida: deve ser 4, 8 ou 16 (recebido: 5)."),
-    
-    ("Tentativa fora do limite (4)", 
-     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 4, "tentativa": 4, "bateria": 90}, 
-     "Tentativa fora do limite: deve ser 1, 2 ou 3 (recebido: 4)."),
-    
-    ("Bateria fora do limite (110)", 
-     {"id_corrida": 1, "timestamp_ms": 0, "dimensao": 4, "tentativa": 1, "bateria": 110}, 
-     "Bateria fora do range [0, 100] (recebido: 110)."),
-
-    # Pacote Final
-    ("Sucesso não booleano", 
-     {"id_corrida": 1, "timestamp_ms": 1000, "sucesso": "ok", "v_med": 10, "bateria": 80}, 
-     "Campo 'sucesso' deve ser booleano (recebido: ok)."),
-    
-    ("v_med negativo", 
-     {"id_corrida": 1, "timestamp_ms": 1000, "sucesso": True, "v_med": -1, "bateria": 80}, 
-     "Campo 'v_med' não pode ser negativo (recebido: -1)."),
+    ("Falta campo tipo", {"timestamp_ms": 100, "dimensao": 4, "bateria": 90}, "Tipo de pacote não reconhecido."),
+    ("Tipo desconhecido (99)", {"tipo": 99, "timestamp_ms": 100, "dimensao": 4, "bateria": 90}, "Tipo de pacote não reconhecido."),
+    ("Timestamp negativo", {"tipo": 0, "timestamp_ms": -10, "dimensao": 4, "bateria": 90}, "Campo 'timestamp_ms' não pode ser negativo (recebido: -10)."),
+    ("Dimensão inválida (5)", {"tipo": 0, "timestamp_ms": 0, "dimensao": 5, "bateria": 90}, "Dimensão inválida: deve ser 4, 8 ou 16 (recebido: 5)."),
+    ("Bateria fora do limite (110)", {"tipo": 0, "timestamp_ms": 0, "dimensao": 4, "bateria": 110}, "Bateria fora do range [0, 100] (recebido: 110)."),
+    ("Sucesso não booleano", {"tipo": 3, "timestamp_ms": 1000, "sucesso": "ok", "v_med": 10, "bateria": 80}, "Campo 'sucesso' deve ser booleano (recebido: ok)."),
+    ("v_med negativo", {"tipo": 3, "timestamp_ms": 1000, "sucesso": True, "v_med": -1, "bateria": 80}, "Campo 'v_med' não pode ser negativo (recebido: -1)."),
+    ("w fora do range (16)", {"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 16}, "Campo 'w' fora do range [0, 15] (recebido: 16)."),
 ])
 def test_falhas_validacao_barreira(client: TestClient, session: Session, nome_caso, payload, erro_esperado):
-    """Garante que a barreira de validação bloqueia dados inválidos e não persiste nada."""
     response = client.post("/api/telemetria/pacote", json=payload)
-    
     assert response.status_code == 422
     data = response.json()
     assert data["detail"]["mensagem"] == "Pacote descartado"
     assert any(erro_esperado in e for e in data["detail"]["erros"])
-    
-    # Garante que não foi criada nenhuma corrida no banco (para IDs novos)
-    if "id_corrida" in payload and isinstance(payload["id_corrida"], int):
-        corrida = session.exec(select(Corrida).where(Corrida.sessao_hardware_id == payload["id_corrida"])).first()
-        assert corrida is None
 
 def test_falha_timestamp_regressivo_isolado(client: TestClient):
-    """Valida especificamente a regra de não aceitar tempo voltando."""
-    id_sessao = 888
-    # Envia pacote inicial em t=5000
-    client.post("/api/telemetria/pacote", json={
-        "id_corrida": id_sessao, "timestamp_ms": 5000, "dimensao": 4, "tentativa": 1, "bateria": 90
-    })
-    
-    # Envia movimentação em t=4000 (Inválido!)
-    payload_regressivo = {
-        "id_corrida": id_sessao, "timestamp_ms": 4000, "x": 1, "y": 1, "w": 0
-    }
-    response = client.post("/api/telemetria/pacote", json=payload_regressivo)
-    
+    client.post("/api/telemetria/pacote", json={"tipo": 0, "timestamp_ms": 5000, "dimensao": 4, "bateria": 90})
+    response = client.post("/api/telemetria/pacote", json={"tipo": 1, "timestamp_ms": 4000, "x": 1, "y": 1, "w": 0})
     assert response.status_code == 422
     assert "Timestamp regressivo: 4000 < último válido 5000." in response.json()["detail"]["erros"]
+
+def test_pacote_nao_inicial_sem_sessao_ativa(client: TestClient):
+    response = client.post("/api/telemetria/pacote", json={"tipo": 1, "timestamp_ms": 1000, "x": 0, "y": 0, "w": 0})
+    assert response.status_code == 409

--- a/src/backend/tests/test_websocket.py
+++ b/src/backend/tests/test_websocket.py
@@ -9,11 +9,7 @@ def test_websocket_connection(client:TestClient):
 
 def test_telemetry_post_endpoint(client:TestClient):
     response = client.post("/api/telemetria/pacote", json={
-        "id_corrida": 1,
-        "timestamp_ms": 1000,
-        "dimensao": 4,
-        "tentativa": 1,
-        "bateria": 10
+        "tipo": 0, "timestamp_ms": 1000, "dimensao": 4, "bateria": 10
     })
     assert response.status_code == 201
     assert response.json()["message"] == "Pacote processado com sucesso"
@@ -24,31 +20,20 @@ def test_websocket_message_delivery(client:TestClient):
     with client.websocket_connect("/api/telemetria/ws") as websocket:
         msg_conexao = websocket.receive_json()
         assert msg_conexao["type"] == "HANDSHAKE"
-        assert msg_conexao["data"]["status"] == "connected"
 
-        # Enviamos um pacote de telemetria
         response = client.post("/api/telemetria/pacote", json={
-            "id_corrida": 1,
-            "timestamp_ms": 1000,
-            "dimensao": 4,
-            "tentativa": 1,
-            "bateria": 100
+            "tipo": 0, "timestamp_ms": 1000, "dimensao": 4, "bateria": 100
         })
         assert response.status_code == 201
 
-        # O connection_monitor envia CONNECTION_STATUS (online) antes do SESSAO_INICIADA
         msg_conexao_status = websocket.receive_json()
         assert msg_conexao_status["type"] == "CONNECTION_STATUS"
         assert msg_conexao_status["data"]["status"] == "online"
-        assert msg_conexao_status["data"]["id_corrida"] == 1
 
-        # Em seguida, recebemos o evento de telemetria
         message = websocket.receive_json()
-
-        # Valida os dados reais transmitidos
         assert message["type"] == "SESSAO_INICIADA"
         assert message["data"]["id_corrida_banco"] is not None
-        assert message["data"]["bateria_inicial"] == 100.0
+        assert message["data"]["bateria_inicial"] == 100
         assert message["data"]["dimensao"] == "4X4"
         assert message["data"]["alerta_possivel_parada_inesperada"] is False
         assert message["data"]["log_alertas"] == []

--- a/src/frontend/src/__tests__/integration/DashboardIndicadores.integration.test.tsx
+++ b/src/frontend/src/__tests__/integration/DashboardIndicadores.integration.test.tsx
@@ -48,7 +48,7 @@ function configurarHook(
     statusConexao: conectado ? "online" : "waiting",
     mensagemStatusConexao: null,
     conectado,
-    configSessao: { dimensao: null, tentativa: null },
+    configSessao: { dimensao: null },
     enviarPacote: vi.fn(),
     erro: null,
   } as ReturnType<typeof useTelemetria>);

--- a/src/frontend/src/__tests__/unit/DashboardIndicadores.test.tsx
+++ b/src/frontend/src/__tests__/unit/DashboardIndicadores.test.tsx
@@ -47,7 +47,7 @@ function configurarHook(
     statusConexao: conectado ? "online" : "waiting",
     mensagemStatusConexao: null,
     conectado,
-    configSessao: { dimensao: null, tentativa: null },
+    configSessao: { dimensao: null },
     enviarPacote: vi.fn(),
     erro: null,
   } as ReturnType<typeof useTelemetria>);

--- a/src/frontend/src/components/Session.tsx
+++ b/src/frontend/src/components/Session.tsx
@@ -84,12 +84,7 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
             </p>
 
             <div className="space-y-3 mb-8">
-              <div className="bg-slate-50 border border-slate-100 p-3 rounded-2xl flex justify-between items-center text-sm">
-                <span className="text-slate-500">Tentativa:</span>
-                <span className="font-mono font-bold text-slate-800 bg-white px-2 py-0.5 rounded-md border border-slate-200 shadow-xs">
-                  #{configSessao.tentativa}
-                </span>
-              </div>
+
               <div className="bg-slate-50 border border-slate-100 p-3 rounded-2xl flex justify-between items-center text-sm">
                 <span className="text-slate-500">Dimensão do Labirinto</span>
                 <span className="font-mono font-bold text-slate-800 bg-white px-2 py-0.5 rounded-md border border-slate-200 shadow-xs">

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -19,7 +19,6 @@ import { WS_TELEMETRIA_URL } from "../services/telemetria";
 
 type StatusConexaoMicromouse = "online" | "offline" | "waiting";
 
-/** Estado inicial dos indicadores (espelha criar_estado_inicial do backend). */
 const ESTADO_INICIAL: IndicadoresDesempenho = {
   id_corrida_banco: null,
   sessao_hardware_id: null,
@@ -33,12 +32,14 @@ const ESTADO_INICIAL: IndicadoresDesempenho = {
   sucesso: null,
   ultimo_timestamp_ms: null,
   alerta_bateria_critica: false,
+  alerta_possivel_parada_inesperada: false,
   alerta_dado_invalido: false,
+  alerta_temperatura_critica: false,
+  log_alertas: [],
 };
 
 const CONFIG_SESSAO_INICIAL: ConfigSessao = {
   dimensao: null,
-  tentativa: null,
 };
 
 /** Intervalo entre tentativas de reconexão (ms). */
@@ -137,15 +138,27 @@ export function useTelemetria(): UseTelemetriaReturn {
         const pacote = parsed?.data;
 
         if (parsed.type === "SESSAO_INICIADA") {
-          const { dimensao, tentativa, ...indicadoresData } = pacote;
+          const { dimensao, ...indicadoresData } = pacote;
           setIndicadores(indicadoresData as IndicadoresDesempenho);
-          setConfigSessao({ dimensao, tentativa });
+          setConfigSessao({ dimensao });
           setStatusConexao("online");
           setMensagemStatusConexao(null);
-        } else if (parsed.type === "ATUALIZACAO_TELEMETRIA") {
+        } else if (
+          parsed.type === "ATUALIZACAO_TELEMETRIA" ||
+          parsed.type === "HEARTBEAT"
+        ) {
           setIndicadores(pacote as IndicadoresDesempenho);
           setStatusConexao("online");
           setMensagemStatusConexao(null);
+        } else if (parsed.type === "ALERTA_TEMPERATURA_CRITICA") {
+          const { temp_c, ...indicadoresData } = pacote;
+          setIndicadores(indicadoresData as IndicadoresDesempenho);
+          setStatusConexao("online");
+          setMensagemStatusConexao(null);
+          toast.error(`Alerta Crítico: Temperatura em ${temp_c}ºC! Corrida abortada.`, {
+            id: "alerta-temperatura",
+            duration: 5000,
+          });
         }
       } catch (e) {
         console.error("[useTelemetria] Erro ao processar mensagem:", e);

--- a/src/frontend/src/types/telemetria.ts
+++ b/src/frontend/src/types/telemetria.ts
@@ -20,38 +20,70 @@ export type StatusCorridaTelemetria =
 
 /** Pacote de início/configuração da corrida. */
 export interface PacoteInicial {
-  id_corrida: number;
+  tipo: number;
   timestamp_ms: number;
-  dimensao: string;
-  tentativa: number;
+  dimensao: number;
   bateria: number;
 }
 
 /** Pacote de movimentação durante a corrida. */
 export interface PacoteMovimentacao {
-  id_corrida: number;
+  tipo: number;
   timestamp_ms: number;
   x: number;
   y: number;
   w: number;
-  bateria?: number;
+}
+
+/** Pacote contendo a rota otimizada calculada. */
+export interface PacoteRota {
+  tipo: number;
+  timestamp_ms: number;
+  rota: number[][];
 }
 
 /** Pacote consolidado ao fim da corrida. */
 export interface PacoteFinal {
-  id_corrida: number;
+  tipo: number;
   timestamp_ms: number;
   sucesso: boolean;
   v_med: number;
   bateria: number;
 }
 
+/** Sinal periódico de vida da conexão. */
+export interface PacoteHeartbeat {
+  tipo: number;
+  timestamp_ms: number;
+  bateria: number;
+}
+
+/** Alerta crítico de temperatura. */
+export interface PacoteAlertaTemperatura {
+  tipo: number;
+  timestamp_ms: number;
+  temp_c: number;
+}
+
 /** Union type de todos os pacotes de telemetria. */
-export type PacoteTelemetria = PacoteInicial | PacoteMovimentacao | PacoteFinal;
+export type PacoteTelemetria = 
+  | PacoteInicial 
+  | PacoteMovimentacao 
+  | PacoteRota
+  | PacoteFinal
+  | PacoteHeartbeat
+  | PacoteAlertaTemperatura;
 
 // ---------------------------------------------------------------------------
 // Estado dos indicadores
 // ---------------------------------------------------------------------------
+
+/** Registro técnico de um alerta crítico detectado. */
+export interface AlertaTelemetria {
+  tipo: string;
+  mensagem: string;
+  timestamp_ms: number;
+}
 
 /** Estado consolidado dos indicadores de desempenho do dashboard. */
 export interface IndicadoresDesempenho {
@@ -67,10 +99,12 @@ export interface IndicadoresDesempenho {
   sucesso: boolean | null;
   ultimo_timestamp_ms: number | null;
   alerta_bateria_critica: boolean;
+  alerta_possivel_parada_inesperada: boolean;
   alerta_dado_invalido: boolean;
+  alerta_temperatura_critica: boolean;
+  log_alertas: AlertaTelemetria[];
 }
 
 export interface ConfigSessao {
   dimensao: number | string | null;
-  tentativa: number | string | null;
 }


### PR DESCRIPTION
# Descrição do Pull Request

## Objetivo
Implementar a extensão do protocolo de telemetria conforme definido no documento `telemetria.md`. O foco principal desta alteração é a introdução de novos tipos de pacotes para monitoramento contínuo e segurança (**Heartbeat** e **Alerta Crítico de Temperatura**), a remoção de campos legados e o aprimoramento da resiliência do sistema de sessões ativas tanto no backend quanto no frontend.

---

## Alterações Realizadas

###  Backend

#### 1. Schemas e Validação (`app/schemas/telemetria.py` & `app/services/telemetria.py`)
*   **Novos Pacotes:** Adição dos schemas Pydantic `PacoteHeartbeat` (tipo `4`) e `PacoteAlertaTemperatura` (tipo `5`).
*   **Estrutura de Tipos:** Atualização do Enum `TipoPacote` e inclusão do evento `TEMPERATURA_CRITICA` em `TipoAlertaTelemetria`.
*   **Validação Estrita:** Implementação de funções dedicadas (`_validar_pacote_heartbeat` e `_validar_pacote_alerta_temperatura`) assegurando que dados incoerentes ou incompletos sejam descartados logo na barreira de entrada.
*   **Estado Consolidado:** Expansão de `IndicadoresDesempenho` para acomodar a nova flag `alerta_temperatura_critica` e a lista `log_alertas`.

#### 2. Processamento e Regras de Negócio (`app/services/telemetria.py`)
*   **Heartbeat (`tipo=4`):** Atualiza o timestamp e a porcentagem de carga de bateria. Caso a carga atinja ≤ 10%, gera o alerta crítico de bateria.
*   **Alerta de Temperatura (`tipo=5`):** Registra o evento de alerta térmico e, caso haja uma corrida ativa, **aborta a corrida imediatamente** no backend, mudando o status para `FALHA` e fixando o tempo do ocorrido.

#### 3. Persistência e Broadcast (`app/routers/telemetria.py`)
*   **Broadcast de Eventos:** WebSocket agora propaga os tipos específicos `HEARTBEAT` e `ALERTA_TEMPERATURA_CRITICA` aos dashboards conectados.
*   **Persistência Automática:** Quando o robô emite um pacote de temperatura crítica, o backend persiste automaticamente a corrida no banco de dados com status `ABORTADA` (via SQLAlchemy/SQLModel).
*   **Indicadores:** A função utilitária `_estado_to_dict` foi atualizada para expor a flag `alerta_temperatura_critica` aos clientes do WebSocket.

#### 4. Testes Automatizados (`tests/test_novos_pacotes.py` [NEW])
*   Implementada uma suíte abrangente de testes unitários e de integração validando:
    *   Validação estrita de intervalos e tipos para Heartbeat e Temperatura.
    *   Comportamento de aborto automático e registro de falhas.
    *   Persistência correta dos alertas de temperatura e bateria crítica na tabela de `Evento`.

---

### 💻 Frontend (React / TypeScript)

#### 1. Tipagem Unificada (`src/types/telemetria.ts`)
*   **Remoção de Campos Obsoletos:** `id_corrida` e `tentativa` foram inteiramente descontinuados dos pacotes de telemetria (`PacoteInicial`, `PacoteMovimentacao` e `PacoteFinal`), visto que o backend agora coordena a sessão única dinamicamente.
*   **Novas Interfaces:** Definição dos tipos `PacoteHeartbeat`, `PacoteAlertaTemperatura` e `PacoteRota`.
*   **Indicadores de Estado:** Inclusão de `alerta_temperatura_critica`, `alerta_possivel_parada_inesperada` e `log_alertas: AlertaTelemetria[]` no estado geral.

#### 2. Gerenciador de Estado em Tempo Real (`src/hooks/useTelemetria.ts`)
*   **Recepção WebSocket:**
    *   `HEARTBEAT`: Atualiza o nível de bateria do Micromouse em tempo real no dashboard e redefine o status de conexão para `online`.
    *   `ALERTA_TEMPERATURA_CRITICA`: Dispara um alerta visual imediato via `toast.error` notificando a temperatura exata e que a corrida foi abortada por segurança.
*   **Consistência:** Ajuste do `ESTADO_INICIAL` e da desestruturação do pacote `SESSAO_INICIADA` para remover referências à `tentativa`.

#### 3. Componentes e Testes (`src/components/Session.tsx` & Testes)
*   **Ajuste de UI:** Removido o elemento visual que exibia o contador de tentativas da tela de aguardo de monitoramento.
*   **Testes Atualizados:** Corrigidos os mocks dos testes unitários e de integração (`DashboardIndicadores.integration.test.tsx` e `DashboardIndicadores.test.tsx`) para bypassar o campo de tentativas deletado.

---

## Como Testar

### Backend:
Execute a suíte de testes do Pytest:
```bash
cd src/backend
.venv/bin/python -m pytest tests/ -v
```
*(Garante o funcionamento correto de toda a regra de validação e persistência do Heartbeat e alertas de Temperatura - 144 testes passando).*

### Frontend:
Execute a suíte de testes do Vitest:
```bash
cd src/frontend
npm run test
```
*(Garante a integridade do Dashboard de indicadores sem quebra de tela - 51 testes passando).*