### PR TITLE
Refatoração de UI/UX e Padronização do Dashboard de Monitoramento (US-12)

### DIFF
--- a/src/frontend/src/__tests__/integration/DashboardIndicadores.integration.test.tsx
+++ b/src/frontend/src/__tests__/integration/DashboardIndicadores.integration.test.tsx
@@ -51,7 +51,7 @@ function configurarHook(
     configSessao: { dimensao: null },
     enviarPacote: vi.fn(),
     erro: null,
-  } as ReturnType<typeof useTelemetria>);
+  } as unknown as ReturnType<typeof useTelemetria>);
 }
 
 beforeEach(() => { vi.useFakeTimers(); });

--- a/src/frontend/src/__tests__/unit/DashboardIndicadores.test.tsx
+++ b/src/frontend/src/__tests__/unit/DashboardIndicadores.test.tsx
@@ -50,7 +50,7 @@ function configurarHook(
     configSessao: { dimensao: null },
     enviarPacote: vi.fn(),
     erro: null,
-  } as ReturnType<typeof useTelemetria>);
+  } as unknown as ReturnType<typeof useTelemetria>);
 }
 
 // ── CT01 

--- a/src/frontend/src/components/DashboardIndicadores.tsx
+++ b/src/frontend/src/components/DashboardIndicadores.tsx
@@ -1,298 +1,183 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-
+import React, { useEffect, useRef, useState } from "react";
 import { useTelemetria, type UseTelemetriaReturn } from "../hooks/useTelemetria";
-import {
-  CriticalAlertModal,
-  type CriticalAlertType,
-} from "./CriticalAlertModal";
+import { CriticalAlertModal, type CriticalAlertType } from "./CriticalAlertModal";
 
-type StatusCorrida =
-  | "aguardando"
-  | "em_andamento"
-  | "concluida"
-  | "abortada";
+type StatusCorrida = "aguardando" | "em_andamento" | "concluida" | "abortada";
 
 const LIMITE_BATERIA_CRITICA = 10;
 const LIMITE_SEM_TELEMETRIA_MS = 3000;
 
 const formatarTempo = (ms?: number | null): string => {
-  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
-    return "00:00.000";
-  }
-
+  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) return "00:00.000";
   const minutos = Math.floor(ms / 60000);
   const segundos = Math.floor((ms % 60000) / 1000);
   const milissegundos = Math.floor(ms % 1000);
-
-  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(
-    2,
-    "0",
-  )}.${String(milissegundos).padStart(3, "0")}`;
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(2, "0")}.${String(milissegundos).padStart(3, "0")}`;
 };
 
 const normalizarStatus = (status?: string | null): StatusCorrida => {
   const valor = status?.toLowerCase();
-
-  if (
-    valor === "em_andamento" ||
-    valor === "concluida" ||
-    valor === "abortada"
-  ) {
-    return valor;
-  }
-
-  if (valor === "falha") {
-    return "abortada";
-  }
-
+  if (valor === "em_andamento" || valor === "concluida" || valor === "abortada") return valor;
+  if (valor === "falha") return "abortada";
   return "aguardando";
 };
 
-const rotuloStatus: Record<StatusCorrida, string> = {
-  aguardando: "Aguardando",
-  em_andamento: "Em andamento",
-  concluida: "Concluída",
-  abortada: "Abortada",
-};
-
 const obterNumeroValido = (valor?: number | null): number | null => {
-  if (valor === null || valor === undefined || Number.isNaN(valor)) {
-    return null;
-  }
-
+  if (valor === null || valor === undefined || Number.isNaN(valor)) return null;
   return valor;
 };
 
-type CardIndicadorProps = {
-  titulo: string;
-  valor: string;
-  descricao?: string;
-  estado?: "normal" | "critico" | "sucesso" | "vazio";
-};
-
-const CardIndicador: React.FC<CardIndicadorProps> = ({
-  titulo,
-  valor,
-  descricao,
-  estado = "normal",
-}) => {
-  const estilos = {
-    normal: "border-neutral-200 bg-white text-neutral-900",
-    critico: "border-red-300 bg-red-50 text-red-950",
-    sucesso: "border-green-300 bg-green-50 text-green-950",
-    vazio: "border-neutral-200 bg-neutral-50 text-neutral-400",
-  }[estado];
-
+export const TopIndicators: React.FC<{ telemetria: UseTelemetriaReturn }> = ({ telemetria }) => {
+  const { indicadores, ultimaMovimentacao } = telemetria;
+  const bateriaAtual = obterNumeroValido(indicadores?.bateria_atual);
+  const bateriaCritica = bateriaAtual !== null && bateriaAtual <= LIMITE_BATERIA_CRITICA;
+  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
+  const corridaConcluida = statusCorrida === "concluida";
+  const tempoDecorridoMs = obterNumeroValido(indicadores?.tempo_decorrido_ms) ?? 0;
+  const tempoFinalMs = obterNumeroValido(indicadores?.tempo_final_ms);
+  const tempoExibido = corridaConcluida && tempoFinalMs !== null ? tempoFinalMs : tempoDecorridoMs;
+  const velocidadeMedia = obterNumeroValido(indicadores?.velocidade_media);
+  const xPos = ultimaMovimentacao ? ultimaMovimentacao.x : 0;
+  const yPos = ultimaMovimentacao ? ultimaMovimentacao.y : 0;
+  
   return (
-    <section className={`rounded-xl border p-5 transition-colors ${estilos}`}>
-      <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
-        {titulo}
-      </p>
-      <p className="mt-3 text-3xl font-semibold tracking-tight">{valor}</p>
-      {descricao && <p className="mt-2 text-xs text-current opacity-75">{descricao}</p>}
-    </section>
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-3 sm:p-4 flex flex-col justify-between shadow-sm">
+        <span className="text-[10px] sm:text-[11px] uppercase font-bold text-zinc-500 tracking-wider">Bateria</span>
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-lg sm:text-2xl font-mono font-bold text-white">{bateriaAtual !== null ? `${bateriaAtual.toFixed(1)}%` : "--%"}</span>
+          <div className="w-10 sm:w-12 h-4 sm:h-5 border-2 border-zinc-700 rounded-sm relative flex items-center p-[2px]">
+            <div className="absolute -right-[5px] top-1/2 -translate-y-1/2 w-[3px] h-2 sm:h-2.5 bg-zinc-700 rounded-r-sm"></div>
+            <div className={`h-full rounded-sm transition-all duration-300 ${bateriaCritica ? 'bg-rose-500 animate-pulse' : (bateriaAtual ?? 0) < 40 ? 'bg-yellow-500' : 'bg-emerald-500'}`} style={{ width: `${bateriaAtual ?? 0}%` }}></div>
+          </div>
+        </div>
+      </div>
+      
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-3 sm:p-4 flex flex-col justify-between shadow-sm">
+        <span className="text-[10px] sm:text-[11px] uppercase font-bold text-zinc-500 tracking-wider">Velocidade Média</span>
+        <span className="text-lg sm:text-2xl font-mono font-bold text-white mt-2">{velocidadeMedia !== null ? `${velocidadeMedia.toFixed(1)} cm/s` : "--"}</span>
+      </div>
+
+      <div className="bg-surface border border-border rounded-xl p-3 sm:p-4 flex flex-col justify-between shadow-sm">
+        <span className="text-[10px] sm:text-[11px] uppercase font-bold text-zinc-500 tracking-wider">Tempo Decorrido</span>
+        <span className="text-lg sm:text-2xl font-mono font-bold text-primary mt-2">{formatarTempo(tempoExibido)}</span>
+      </div>
+
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-3 sm:p-4 flex flex-col justify-between shadow-sm">
+        <span className="text-[10px] sm:text-[11px] uppercase font-bold text-zinc-500 tracking-wider">Posição Atual</span>
+        <span className="text-lg sm:text-2xl font-mono font-bold text-white mt-2">({xPos}, {yPos})</span>
+      </div>
+    </div>
   );
 };
 
-type DashboardIndicadoresProps = {
-  telemetria?: Partial<UseTelemetriaReturn>;
+export const ControlPanel: React.FC<{ telemetria: UseTelemetriaReturn }> = ({ telemetria }) => {
+  const { indicadores, configSessao, statusConexao } = telemetria;
+  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
+  const idCorrida = indicadores?.id_corrida_banco ? `#${indicadores.id_corrida_banco}` : "Nenhuma";
+  const dimensaoGrid = configSessao?.dimensao ? (String(configSessao.dimensao).toLowerCase().includes('x') ? String(configSessao.dimensao) : `${configSessao.dimensao}x${configSessao.dimensao}`) : "--x--";
+
+  return (
+    <div className="flex flex-col gap-3 bg-zinc-950 border border-zinc-800 rounded-xl p-4 shadow-sm w-full h-fit">
+      <h3 className="text-[11px] font-bold uppercase text-zinc-500 mb-1 border-b border-zinc-800/50 pb-2 tracking-wider">Controle da Sessão</h3>
+      
+      <div className="flex justify-between items-center">
+        <span className="text-[11px] font-medium text-zinc-400">Conexão</span>
+        <div className="flex items-center gap-1.5">
+          <span className={`w-2 h-2 rounded-full ${statusConexao === 'online' ? 'bg-emerald-500 animate-pulse' : 'bg-rose-500'}`}></span>
+          <span className={`text-[11px] font-bold uppercase ${statusConexao === 'online' ? 'text-emerald-400' : 'text-rose-400'}`}>
+            {statusConexao === 'online' ? 'Online' : 'Offline'}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex justify-between items-center">
+        <span className="text-[11px] font-medium text-zinc-400">Corrida ID</span>
+        <span className="text-xs font-bold text-zinc-200">{idCorrida}</span>
+      </div>
+
+      <div className="flex justify-between items-center">
+        <span className="text-[11px] font-medium text-zinc-400">Grade</span>
+        <span className="text-xs font-bold text-zinc-200">{dimensaoGrid}</span>
+      </div>
+
+      <div className="flex flex-col mt-1 pt-3 border-t border-zinc-800/50 gap-1">
+        <span className="text-[10px] uppercase font-bold text-zinc-500 tracking-wider">Modo de Execução</span>
+        <span className="text-sm font-bold text-primary">{statusCorrida === 'aguardando' ? 'Aguardando' : statusCorrida === 'em_andamento' ? 'Mapeamento' : 'Finalizado'}</span>
+      </div>
+    </div>
+  );
 };
 
-export const DashboardIndicadores: React.FC<DashboardIndicadoresProps> = ({
-  telemetria,
-}) => {
-  const telemetriaHook = useTelemetria();
-  const {
-    indicadores,
-    conectado,
-  } = (telemetria ?? telemetriaHook) as UseTelemetriaReturn;
-
+export const TelemetryAlerts: React.FC<{ telemetria: UseTelemetriaReturn }> = ({ telemetria }) => {
+  const { indicadores } = telemetria;
+  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
+  const bateriaAtual = obterNumeroValido(indicadores?.bateria_atual);
+  const ultimoTimestampMs = obterNumeroValido(indicadores?.ultimo_timestamp_ms);
+  
   const [alertaSemSinal, setAlertaSemSinal] = useState(false);
-  const [alertaCritico, setAlertaCritico] = useState<{
-    type: CriticalAlertType;
-    key: string;
-  } | null>(null);
+  const [alertaCritico, setAlertaCritico] = useState<{ type: CriticalAlertType; key: string; } | null>(null);
+
+  const bateriaCritica = bateriaAtual !== null && bateriaAtual <= LIMITE_BATERIA_CRITICA;
+  const paradaInesperada = indicadores?.alerta_possivel_parada_inesperada === true;
 
   const bateriaCriticaAbertaRef = useRef(false);
   const paradaInesperadaAbertaRef = useRef(false);
 
-  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
-  const corridaAguardando = !indicadores || statusCorrida === "aguardando";
-  const corridaConcluida = statusCorrida === "concluida";
-  const corridaAbortada = statusCorrida === "abortada";
-
-  const bateriaAtual = obterNumeroValido(indicadores?.bateria_atual);
-  const velocidadeMedia = obterNumeroValido(indicadores?.velocidade_media);
-  const tempoDecorridoMs = obterNumeroValido(indicadores?.tempo_decorrido_ms) ?? 0;
-  const tempoFinalMs = obterNumeroValido(indicadores?.tempo_final_ms);
-  const ultimoTimestampMs = obterNumeroValido(indicadores?.ultimo_timestamp_ms);
-
-  const bateriaCritica = bateriaAtual !== null && bateriaAtual <= LIMITE_BATERIA_CRITICA;
-  const paradaInesperada =
-    indicadores?.alerta_possivel_parada_inesperada === true;
-
-  const tempoExibido = useMemo(() => {
-    if (corridaConcluida && tempoFinalMs !== null) {
-      return tempoFinalMs;
-    }
-
-    return tempoDecorridoMs;
-  }, [corridaConcluida, tempoDecorridoMs, tempoFinalMs]);
-
   useEffect(() => {
     let timer: number | undefined;
-
     if (indicadores && statusCorrida === "em_andamento") {
       setAlertaSemSinal(false);
-      timer = window.setTimeout(() => {
-        setAlertaSemSinal(true);
-      }, LIMITE_SEM_TELEMETRIA_MS);
+      timer = window.setTimeout(() => setAlertaSemSinal(true), LIMITE_SEM_TELEMETRIA_MS);
     } else {
       setAlertaSemSinal(false);
     }
-
-    return () => {
-      if (timer) window.clearTimeout(timer);
-    };
+    return () => { if (timer) window.clearTimeout(timer); };
   }, [indicadores, statusCorrida, ultimoTimestampMs]);
 
   useEffect(() => {
-    if (!bateriaCritica) {
-      bateriaCriticaAbertaRef.current = false;
-      return;
-    }
-
-    if (bateriaCriticaAbertaRef.current) {
-      return;
-    }
-
+    if (!bateriaCritica) { bateriaCriticaAbertaRef.current = false; return; }
+    if (bateriaCriticaAbertaRef.current) return;
     bateriaCriticaAbertaRef.current = true;
-    setAlertaCritico({
-      type: "battery",
-      key: `battery-${ultimoTimestampMs ?? Date.now()}`,
-    });
+    setAlertaCritico({ type: "battery", key: `battery-${ultimoTimestampMs ?? Date.now()}` });
   }, [bateriaCritica, ultimoTimestampMs]);
 
   useEffect(() => {
-    if (!paradaInesperada) {
-      paradaInesperadaAbertaRef.current = false;
-      return;
-    }
-
-    if (paradaInesperadaAbertaRef.current) {
-      return;
-    }
-
+    if (!paradaInesperada) { paradaInesperadaAbertaRef.current = false; return; }
+    if (paradaInesperadaAbertaRef.current) return;
     paradaInesperadaAbertaRef.current = true;
-    setAlertaCritico({
-      type: "stopped",
-      key: `stopped-${ultimoTimestampMs ?? Date.now()}`,
-    });
+    setAlertaCritico({ type: "stopped", key: `stopped-${ultimoTimestampMs ?? Date.now()}` });
   }, [paradaInesperada, ultimoTimestampMs]);
 
   return (
     <>
-      <CriticalAlertModal
-        open={alertaCritico !== null}
-        type={alertaCritico?.type}
-        soundKey={alertaCritico?.key ?? null}
-        onDismiss={() => setAlertaCritico(null)}
-        onConfirm={() => setAlertaCritico(null)}
-      />
-
-      <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-        <header className="mb-6 flex flex-col gap-3 border-b border-neutral-100 pb-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
-              Telemetria
-            </p>
-            <h2 className="text-2xl font-semibold text-neutral-950">
-              Indicadores de Desempenho
-            </h2>
-            <p className="mt-1 text-sm text-neutral-500">
-              Métricas em tempo real da corrida do Micromouse.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-2 text-xs">
-            <span
-              className={`rounded-full px-3 py-1 font-medium ${
-                conectado
-                  ? "bg-green-100 text-green-700"
-                  : "bg-red-100 text-red-700"
-              }`}
-            >
-              WebSocket: {conectado ? "Conectado" : "Desconectado"}
-            </span>
-            <span className="rounded-full bg-neutral-100 px-3 py-1 font-medium text-neutral-700">
-              Corrida: {rotuloStatus[statusCorrida]}
-            </span>
-          </div>
-        </header>
-
-        <div className="mb-5 space-y-3">
+      <CriticalAlertModal open={alertaCritico !== null} type={alertaCritico?.type} soundKey={alertaCritico?.key ?? null} onDismiss={() => setAlertaCritico(null)} onConfirm={() => setAlertaCritico(null)} />
+      {(bateriaCritica || alertaSemSinal) && (
+        <div className="w-full flex flex-col gap-2 mt-2">
           {bateriaCritica && (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
-              ⚠️ Bateria crítica: nível em {bateriaAtual?.toFixed(1)}% ou menos.
+            <div className="rounded-lg border border-danger/20 bg-danger/10 px-4 py-2 text-xs font-bold text-danger">
+              ⚠️ Bateria crítica: {bateriaAtual?.toFixed(1)}%
             </div>
           )}
-
           {alertaSemSinal && (
-            <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm font-medium text-yellow-800">
-              ⚠️ Ausência de telemetria recente: sem novos pacotes há mais de 3 segundos.
+            <div className="rounded-lg border border-warning/20 bg-warning/10 px-4 py-2 text-xs font-bold text-warning">
+              ⚠️ Ausência de telemetria recente.
             </div>
           )}
         </div>
-
-        <main className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <CardIndicador
-            titulo="Bateria"
-            valor={corridaAguardando || bateriaAtual === null ? "--%" : `${bateriaAtual.toFixed(1)}%`}
-            descricao={
-              bateriaCritica
-                ? "Bateria crítica"
-                : corridaAguardando
-                  ? "Aguardando telemetria"
-                  : "Última bateria conhecida"
-            }
-            estado={corridaAguardando ? "vazio" : bateriaCritica ? "critico" : "normal"}
-          />
-
-          <CardIndicador
-            titulo="Velocidade média"
-            valor={
-              corridaAguardando || velocidadeMedia === null || velocidadeMedia < 0
-                ? "-- cm/s"
-                : `${velocidadeMedia.toFixed(2)} cm/s`
-            }
-            descricao={corridaAguardando ? "Aguardando deslocamento" : "Calculada pela telemetria"}
-            estado={corridaAguardando ? "vazio" : "normal"}
-          />
-
-          <CardIndicador
-            titulo={corridaConcluida || corridaAbortada ? "Tempo final" : "Tempo decorrido"}
-            valor={corridaAguardando ? "00:00.000" : formatarTempo(tempoExibido)}
-            descricao={
-              corridaConcluida
-                ? "Tempo fixado após conclusão"
-                : corridaAbortada
-                  ? "Tempo fixado após encerramento"
-                  : corridaAguardando
-                    ? "Aguardando largada"
-                    : "Atualizado durante a corrida"
-            }
-            estado={
-              corridaAguardando
-                ? "vazio"
-                : corridaConcluida
-                  ? "sucesso"
-                  : corridaAbortada
-                    ? "critico"
-                    : "normal"
-            }
-          />
-        </main>
-      </div>
+      )}
     </>
+  );
+};
+
+export const DashboardIndicadores: React.FC<{ telemetria?: UseTelemetriaReturn }> = ({ telemetria }) => {
+  const telemetriaHook = useTelemetria();
+  const t = telemetria ?? telemetriaHook;
+  return (
+    <div className="flex flex-col gap-4">
+      <TopIndicators telemetria={t} />
+      <ControlPanel telemetria={t} />
+      <TelemetryAlerts telemetria={t} />
+    </div>
   );
 };

--- a/src/frontend/src/components/MonitoringLayout.tsx
+++ b/src/frontend/src/components/MonitoringLayout.tsx
@@ -1,7 +1,9 @@
+import React, { useState } from "react";
+
 type MonitoringLayoutProps = {
   activeView: "telemetria" | "labirinto";
   onNavigateTelemetria: () => void;
-  onNavigateLabirinto: () => void;
+  onNavigateLabirinto?: () => void;
   eyebrow: string;
   title: string;
   description: string;
@@ -11,17 +13,18 @@ type MonitoringLayoutProps = {
 };
 
 export function MonitoringLayout({
-  activeView,
+  activeView: _activeView,
   onNavigateTelemetria,
-  onNavigateLabirinto,
+  onNavigateLabirinto: _onNavigateLabirinto,
   eyebrow,
   title,
   description,
   statusConexao,
-  mensagemStatusConexao,
+  mensagemStatusConexao: _mensagemStatusConexao,
   children,
 }: MonitoringLayoutProps) {
-  const exibindoLabirinto = activeView === "labirinto";
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
   const statusLabel =
     statusConexao === "online"
       ? "Online"
@@ -30,96 +33,132 @@ export function MonitoringLayout({
         : "Aguardando conexao";
   const statusClasses =
     statusConexao === "online"
-      ? "border-emerald-600 bg-emerald-600 text-white"
+      ? "border-emerald-500/30 bg-emerald-950/40 text-emerald-400"
       : statusConexao === "offline"
-        ? "border-red-200 bg-red-50 text-red-700"
-        : "border-amber-200 bg-amber-50 text-amber-700";
+        ? "border-red-500/30 bg-red-950/40 text-red-400"
+        : "border-amber-500/30 bg-amber-950/40 text-amber-400";
   const statusDotClass =
     statusConexao === "online"
-      ? "bg-white"
+      ? "bg-emerald-500"
       : statusConexao === "offline"
         ? "bg-red-500"
         : "bg-amber-500";
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA] text-zinc-900">
+    <div className="min-h-screen bg-background text-primary">
       <div className="flex min-h-screen">
-        <aside className="hidden w-64 border-r border-zinc-200 bg-white lg:flex lg:flex-col">
-          <div className="flex h-16 items-center gap-3 border-b border-zinc-200 px-5">
-            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-violet-600 text-white">
-              🤖
+        <aside
+          className={`hidden border-r border-border bg-surface lg:flex lg:flex-col transition-all duration-300 sticky top-0 h-screen overflow-hidden ${
+            isCollapsed ? "w-20" : "w-64"
+          }`}
+        >
+          {/* Header do Menu (Área de clique para expandir/recolher) */}
+          <div
+            className={`flex h-16 items-center border-b border-border cursor-pointer hover:bg-surface-hover transition-colors shrink-0 ${
+              isCollapsed ? "justify-center px-0" : "gap-3 px-5"
+            }`}
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            title="Expandir/Recolher Menu"
+          >
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-surface border border-border shadow-sm">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="text-primary"
+              >
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+              </svg>
             </div>
 
-            <div>
-              <h1 className="text-sm font-semibold text-zinc-900">Micromouse</h1>
-              <p className="text-xs text-zinc-500">Control Center</p>
-            </div>
+            {!isCollapsed && (
+              <div className="whitespace-nowrap transition-opacity duration-300">
+                <h1 className="text-sm font-semibold text-primary">Micromouse</h1>
+                <p className="text-xs text-zinc-500">Control Center</p>
+              </div>
+            )}
           </div>
 
-          <nav className="flex-1 space-y-1 px-3 py-6">
-            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
-              <span>▦</span>
-              Visão Geral
-            </button>
-
+          <nav className="flex-1 space-y-2 py-6 overflow-y-auto overflow-x-hidden custom-scrollbar px-3">
             <button
-              type="button"
-              onClick={onNavigateLabirinto}
-              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition ${
-                exibindoLabirinto
-                  ? "bg-zinc-950 text-white"
-                  : "text-zinc-600 hover:bg-zinc-100"
+              className={`flex w-full items-center rounded-lg py-2.5 text-sm text-zinc-400 transition hover:bg-surface-hover hover:text-primary ${
+                isCollapsed ? "justify-center px-0" : "gap-3 px-3"
               }`}
+              title="Visão Geral"
             >
-              <span>⌗</span>
-              Labirinto
+              <span className="shrink-0 text-lg">▦</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Visão Geral</span>}
             </button>
 
             <button
               type="button"
               onClick={onNavigateTelemetria}
-              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition ${
-                exibindoLabirinto
-                  ? "text-zinc-600 hover:bg-zinc-100"
-                  : "bg-zinc-950 font-medium text-white"
+              className={`flex w-full items-center rounded-lg py-2.5 text-sm transition font-semibold bg-primary text-background shadow-sm hover:opacity-90 ${
+                isCollapsed ? "justify-center px-0" : "gap-3 px-3"
               }`}
+              title="Monitoramento"
             >
-              <span>⌁</span>
-              Telemetria
+              <span className="shrink-0 text-lg">⌗</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Monitoramento</span>}
             </button>
 
-            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
-              <span>▣</span>
-              Estados
+            <button
+              className={`flex w-full items-center rounded-lg py-2.5 text-sm text-zinc-400 transition hover:bg-surface-hover hover:text-primary ${
+                isCollapsed ? "justify-center px-0" : "gap-3 px-3"
+              }`}
+              title="Estados"
+            >
+              <span className="shrink-0 text-lg">▣</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Estados</span>}
             </button>
 
-            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
-              <span>↺</span>
-              Histórico
+            <button
+              className={`flex w-full items-center rounded-lg py-2.5 text-sm text-zinc-400 transition hover:bg-surface-hover hover:text-primary ${
+                isCollapsed ? "justify-center px-0" : "gap-3 px-3"
+              }`}
+              title="Histórico"
+            >
+              <span className="shrink-0 text-lg">↺</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Histórico</span>}
             </button>
 
-            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
-              <span>⚙</span>
-              Configuração
+            <button
+              className={`flex w-full items-center rounded-lg py-2.5 text-sm text-zinc-400 transition hover:bg-surface-hover hover:text-primary ${
+                isCollapsed ? "justify-center px-0" : "gap-3 px-3"
+              }`}
+              title="Configuração"
+            >
+              <span className="shrink-0 text-lg">⚙</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Configuração</span>}
             </button>
           </nav>
 
-          <div className="m-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
-            <p className="text-xs font-medium uppercase text-zinc-500">Firmware</p>
-            <div className="mt-2 flex items-center justify-between">
-              <span className="text-xs text-zinc-500">Sincronizado</span>
-              <span className="rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-700">
-                v2.4.1
-              </span>
+          {!isCollapsed ? (
+            <div className="m-3 rounded-lg border border-border bg-background/50 p-3 shrink-0 whitespace-nowrap">
+              <p className="text-xs font-medium uppercase text-zinc-500">Firmware</p>
+              <div className="mt-2 flex items-center justify-between">
+                <span className="text-xs text-zinc-400">Sincronizado</span>
+                <span className="rounded-md bg-surface border border-border px-2 py-1 text-[10px] font-bold text-primary">
+                  v2.4.1
+                </span>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="mb-3 mx-auto shrink-0" title="Firmware Sincronizado v2.4.1">
+               <span className="flex h-8 w-8 items-center justify-center rounded-md bg-surface border border-border text-[10px] font-bold text-primary">
+                  v2
+               </span>
+            </div>
+          )}
         </aside>
 
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="flex h-16 items-center justify-between border-b border-zinc-200 bg-white px-4 lg:px-8">
+        <div className="flex min-w-0 flex-1 flex-col bg-background">
+          <header className="flex h-16 items-center justify-between border-b border-border bg-surface px-4 lg:px-8 shrink-0">
             <div>
               <p className="text-xs text-zinc-500">Sessão #2026-05-02-014</p>
-              <h2 className="text-sm font-medium text-zinc-900">
+              <h2 className="text-sm font-medium text-primary">
                 Painel de Monitoramento — Robô MM-07
               </h2>
             </div>
@@ -129,7 +168,7 @@ export function MonitoringLayout({
                 <input
                   type="text"
                   placeholder="Buscar evento, sessão..."
-                  className="h-9 w-64 rounded-lg border border-zinc-200 bg-white px-3 text-sm outline-none transition placeholder:text-zinc-400 focus:border-violet-500"
+                  className="h-9 w-64 rounded-lg border border-border bg-background px-3 text-sm text-primary outline-none transition placeholder:text-zinc-600 focus:border-primary"
                 />
               </div>
 
@@ -149,29 +188,29 @@ export function MonitoringLayout({
 
               <button
                 type="button"
-                className="flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-white text-sm text-zinc-600"
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-background text-sm text-zinc-400 hover:text-primary transition-colors"
               >
                 🔔
               </button>
 
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-950 text-xs font-semibold text-white">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-xs font-semibold text-background">
                 AL
               </div>
             </div>
           </header>
 
-          <main className="flex-1 px-4 py-8 lg:px-10">
-            <section className="mx-auto w-full max-w-6xl">
+          <main className="flex-1 px-4 py-8 lg:px-10 overflow-auto">
+            <section className="mx-auto w-full max-w-[1600px]">
               <div className="mb-6">
                 <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
                   {eyebrow}
                 </p>
 
-                <h1 className="mt-1 text-2xl font-semibold text-zinc-950">
+                <h1 className="mt-1 text-2xl font-semibold text-primary">
                   {title}
                 </h1>
 
-                <p className="mt-2 max-w-2xl text-sm text-zinc-500">
+                <p className="mt-2 max-w-2xl text-sm text-zinc-400">
                   {description}
                 </p>
               </div>

--- a/src/frontend/src/components/MonitoringLayout.tsx
+++ b/src/frontend/src/components/MonitoringLayout.tsx
@@ -14,7 +14,7 @@ type MonitoringLayoutProps = {
 };
 
 export function MonitoringLayout({
-  activeView: _activeView,
+  activeView,
   onNavigateTelemetria,
   onNavigateLabirinto,
   onNavigateCorridas,
@@ -22,7 +22,6 @@ export function MonitoringLayout({
   title,
   description,
   statusConexao,
-  mensagemStatusConexao: _mensagemStatusConexao,
   children,
 }: MonitoringLayoutProps) {
   const exibindoTelemetria = activeView === "telemetria";
@@ -46,6 +45,8 @@ export function MonitoringLayout({
       : statusConexao === "offline"
         ? "bg-red-500"
         : "bg-amber-500";
+
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   return (
     <div className="min-h-screen bg-background text-primary">
@@ -117,14 +118,24 @@ export function MonitoringLayout({
                   ? "bg-zinc-950 text-white"
                   : "text-zinc-600 hover:bg-zinc-100"
               }`}
+              title="Corridas"
             >
-              <span>↺</span>
-              Corridas
+              <span className="shrink-0 text-lg">↺</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Corridas</span>}
             </button>
 
-            <button className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-600 transition hover:bg-zinc-100">
-              <span>▣</span>
-              Estados
+            <button
+              type="button"
+              onClick={onNavigateLabirinto}
+              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition ${
+                exibindoLabirinto
+                  ? "bg-zinc-950 text-white"
+                  : "text-zinc-600 hover:bg-zinc-100"
+              }`}
+              title="Labirinto"
+            >
+              <span className="shrink-0 text-lg">▣</span>
+              {!isCollapsed && <span className="whitespace-nowrap">Labirinto</span>}
             </button>
 
             <button

--- a/src/frontend/src/components/Session.tsx
+++ b/src/frontend/src/components/Session.tsx
@@ -11,19 +11,19 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
   const sessaoIniciada = indicadores.status_corrida === "em_andamento";
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-900 flex flex-col items-center justify-center p-6 font-sans">
+    <div className="min-h-screen bg-background text-zinc-100 flex flex-col items-center justify-center p-6 font-sans">
       {/* Indicador de conexão com o WebSocket */}
-      <div className="absolute top-6 right-6 flex items-center gap-2 bg-white/80 backdrop-blur-md border border-slate-200/80 px-4 py-2 rounded-full shadow-md">
+      <div className="absolute top-6 right-6 flex items-center gap-2 bg-surface border border-border px-4 py-2 rounded-full shadow-md">
         <span
-          className={`w-2.5 h-2.5 rounded-full ${conectado ? "bg-emerald-500 animate-pulse" : "bg-rose-500"}`}
+          className={`w-2.5 h-2.5 rounded-full ${conectado ? "bg-success animate-pulse" : "bg-danger"}`}
         ></span>
-        <span className="text-xs font-semibold tracking-wider uppercase text-slate-500">
+        <span className="text-xs font-semibold tracking-wider uppercase text-zinc-500">
           {conectado ? "Servidor Conectado" : "Conectando..."}
         </span>
       </div>
 
       {erro && (
-        <div className="absolute top-20 right-6 bg-rose-50 border border-rose-200 text-rose-800 px-4 py-3 rounded-lg text-sm shadow-md backdrop-blur-md">
+        <div className="absolute top-20 right-6 bg-danger/10 border border-danger/25 text-danger px-4 py-3 rounded-lg text-sm shadow-md backdrop-blur-md">
           {erro}
         </div>
       )}
@@ -31,19 +31,21 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
       <div className="w-full max-w-md transition-all duration-500">
         {!sessaoIniciada ? (
           /* FASE 1: AGUARDANDO CONFIGURAÇÃO */
-          <div className="bg-white/80 backdrop-blur-xl border border-slate-200/80 p-8 rounded-3xl text-center shadow-xl relative overflow-hidden">
+          <div className="bg-surface border border-border p-8 rounded-3xl text-center shadow-xl relative overflow-hidden">
             {/* Efeito de brilho de fundo suave */}
-            <div className="absolute -top-24 -left-24 w-48 h-48 bg-blue-500/5 rounded-full blur-3xl"></div>
+            <div className="absolute -top-24 -left-24 w-48 h-48 bg-primary/5 rounded-full blur-3xl"></div>
 
             {/* Ícone Pulsante */}
-            <div className="w-20 h-20 bg-blue-50 border border-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-sm animate-bounce">
-              <span className="text-3xl">🤖</span>
+            <div className="w-20 h-20 bg-primary/10 border border-primary/20 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-sm animate-bounce">
+              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="currentColor" className="text-primary">
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+              </svg>
             </div>
 
-            <h2 className="text-2xl font-bold tracking-tight text-slate-900 mb-2">
+            <h2 className="text-2xl font-bold tracking-tight text-white mb-2">
               Aguardando Inicialização
             </h2>
-            <p className="text-slate-500 text-sm leading-relaxed mb-6">
+            <p className="text-zinc-400 text-sm leading-relaxed mb-6">
               O sistema de monitoramento está pronto e ouvindo. Ligue o
               Micromouse para iniciar a sessão automaticamente.
             </p>
@@ -51,49 +53,50 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
             {/* Spinner/Pulse animado */}
             <div className="flex justify-center gap-1.5 py-2">
               <span
-                className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-primary rounded-full animate-pulse"
                 style={{ animationDelay: "0ms" }}
               ></span>
               <span
-                className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-primary rounded-full animate-pulse"
                 style={{ animationDelay: "150ms" }}
               ></span>
               <span
-                className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-primary rounded-full animate-pulse"
                 style={{ animationDelay: "300ms" }}
               ></span>
             </div>
           </div>
         ) : (
           /* FASE 2: SESSÃO INICIADA */
-          <div className="bg-white/90 backdrop-blur-xl border border-emerald-500/20 p-8 rounded-3xl shadow-xl relative overflow-hidden animate-fade-in text-center">
+          <div className="bg-surface border border-success/20 p-8 rounded-3xl shadow-xl relative overflow-hidden animate-fade-in text-center">
             {/* Efeito de brilho verde indicando sucesso */}
-            <div className="absolute -top-24 -right-24 w-48 h-48 bg-emerald-500/5 rounded-full blur-3xl"></div>
+            <div className="absolute -top-24 -right-24 w-48 h-48 bg-success/5 rounded-full blur-3xl"></div>
 
             {/* Ícone de Sucesso */}
-            <div className="w-20 h-20 bg-emerald-50 border border-emerald-100 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-sm">
-              <span className="text-3xl">🤖</span>
+            <div className="w-20 h-20 bg-success/10 border border-success/20 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-sm">
+              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="currentColor" className="text-primary">
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+              </svg>
             </div>
 
-            <h2 className="text-2xl font-bold tracking-tight text-slate-900 mb-2">
+            <h2 className="text-2xl font-bold tracking-tight text-white mb-2">
               Sessão Iniciada!
             </h2>
-            <p className="text-slate-500 text-sm leading-relaxed mb-6">
+            <p className="text-zinc-400 text-sm leading-relaxed mb-6">
               O Micromouse conectou-se com sucesso e o monitoramento em tempo
               real está pronto para ser iniciado.
             </p>
 
             <div className="space-y-3 mb-8">
-
-              <div className="bg-slate-50 border border-slate-100 p-3 rounded-2xl flex justify-between items-center text-sm">
-                <span className="text-slate-500">Dimensão do Labirinto</span>
-                <span className="font-mono font-bold text-slate-800 bg-white px-2 py-0.5 rounded-md border border-slate-200 shadow-xs">
+              <div className="bg-background border border-border p-3 rounded-2xl flex justify-between items-center text-sm">
+                <span className="text-zinc-400">Dimensão do Labirinto</span>
+                <span className="font-mono font-bold text-zinc-200 bg-surface px-2 py-0.5 rounded-md border border-border shadow-xs">
                   {configSessao.dimensao}
                 </span>
               </div>
-              <div className="bg-slate-50 border border-slate-100 p-3 rounded-2xl flex justify-between items-center text-sm">
-                <span className="text-slate-500">Bateria Inicial</span>
-                <span className="font-bold text-emerald-600">
+              <div className="bg-background border border-border p-3 rounded-2xl flex justify-between items-center text-sm">
+                <span className="text-zinc-400">Bateria Inicial</span>
+                <span className="font-bold text-success">
                   {indicadores.bateria_inicial}%
                 </span>
               </div>
@@ -102,7 +105,7 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
             {/* Botão de Redirecionamento */}
             <button
               onClick={onNavigate}
-              className="w-full bg-emerald-500 hover:bg-emerald-600 active:bg-emerald-700 text-white font-semibold py-3.5 px-6 rounded-2xl shadow-lg shadow-emerald-500/20 hover:shadow-emerald-500/30 transition-all duration-200 cursor-pointer"
+              className="w-full bg-success hover:bg-success/90 active:bg-emerald-700 text-background font-semibold py-3.5 px-6 rounded-2xl shadow-lg shadow-success/20 hover:shadow-success/30 transition-all duration-200 cursor-pointer"
             >
               Ir para o Monitoramento
             </button>
@@ -113,7 +116,7 @@ export default function SessionManager({ onNavigate }: SessionManagerProps) {
         {onNavigate && !sessaoIniciada && (
           <button
             onClick={onNavigate}
-            className="mt-4 w-full rounded-2xl border border-slate-300 bg-white/80 px-6 py-3.5 font-semibold text-slate-700 shadow-sm transition-all duration-200 hover:border-slate-400 hover:bg-white cursor-pointer"
+            className="mt-4 w-full rounded-2xl border border-border bg-surface hover:bg-surface-hover px-6 py-3.5 font-semibold text-zinc-300 shadow-sm transition-all duration-200 cursor-pointer"
           >
             Abrir monitoramento e labirinto
           </button>

--- a/src/frontend/src/components/maze/MazeViewer.tsx
+++ b/src/frontend/src/components/maze/MazeViewer.tsx
@@ -1,15 +1,51 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { useTelemetria } from "../../hooks/useTelemetria";
 import { createMaze, isInsideMaze, markVisited, markWall, normalizePathToOrthogonal, hasWallBetween, findGoalArea } from "./mazeUtils";
 import type { Cell, Direction, Position } from "./types";
+import { CriticalAlertModal, type CriticalAlertType } from "../CriticalAlertModal";
+
+const LIMITE_BATERIA_CRITICA = 10;
+const LIMITE_SEM_TELEMETRIA_MS = 3000;
+
+const obterNumeroValido = (valor?: number | null): number | null => {
+  if (valor === null || valor === undefined || Number.isNaN(valor)) {
+    return null;
+  }
+  return valor;
+};
+
+const normalizarStatus = (status?: string | null) => {
+  return status?.toLowerCase() || "aguardando";
+};
+
+const formatarTempo = (ms?: number | null): string => {
+  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
+    return "00:00.000";
+  }
+
+  const minutos = Math.floor(ms / 60000);
+  const segundos = Math.floor((ms % 60000) / 1000);
+  const milissegundos = Math.floor(ms % 1000);
+
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(
+    2,
+    "0",
+  )}.${String(milissegundos).padStart(3, "0")}`;
+};
 
 const DEFAULT_GRID_SIZE = 8;
-const GRID_SIZES = [16, 8, 4] as const;
+
 
 const positionsEqual = (a: Position, b: Position) =>
   a.row === b.row && a.col === b.col;
 
-export default function MazeViewer() {
+type MazeViewerProps = {
+  showHeader?: boolean;
+  showSidebar?: boolean;
+  standalone?: boolean;
+};
+
+export default function MazeViewer({ showHeader = true, showSidebar = true, standalone = false }: MazeViewerProps) {
   const { filaMovimentacoes, limparFilaMovimentacoes, configSessao, indicadores, statusConexao } =
     useTelemetria();
   // Estado principal da corrida e do labirinto.
@@ -40,10 +76,89 @@ export default function MazeViewer() {
   const mazeRef = useRef<Cell[][]>(maze);
   const pathRef = useRef<Position[]>(path);
   const directionRef = useRef<Direction>(direction);
+
+  const [alertaSemSinal, setAlertaSemSinal] = useState(false);
+  const [alertaCritico, setAlertaCritico] = useState<{
+    type: CriticalAlertType;
+    key: string;
+  } | null>(null);
+
+  const bateriaCriticaAbertaRef = useRef(false);
+  const paradaInesperadaAbertaRef = useRef(false);
+
+  const statusCorrida = normalizarStatus(indicadores?.status_corrida);
+  const bateriaAtual = obterNumeroValido(indicadores?.bateria_atual);
+  const velocidadeMedia = obterNumeroValido(indicadores?.velocidade_media);
+  const tempoDecorridoMs = obterNumeroValido(indicadores?.tempo_decorrido_ms) ?? 0;
+  const tempoFinalMs = obterNumeroValido(indicadores?.tempo_final_ms);
+  const ultimoTimestampMs = obterNumeroValido(indicadores?.ultimo_timestamp_ms);
+
+  const bateriaCritica = bateriaAtual !== null && bateriaAtual <= LIMITE_BATERIA_CRITICA;
+  const paradaInesperada = indicadores?.alerta_possivel_parada_inesperada === true;
+
+  const tempoExibido = useMemo(() => {
+    if (statusCorrida === "concluida" && tempoFinalMs !== null) {
+      return tempoFinalMs;
+    }
+    return tempoDecorridoMs;
+  }, [statusCorrida, tempoDecorridoMs, tempoFinalMs]);
+
+  useEffect(() => {
+    let timer: number | undefined;
+
+    if (indicadores && statusCorrida === "em_andamento") {
+      setAlertaSemSinal(false);
+      timer = window.setTimeout(() => {
+        setAlertaSemSinal(true);
+      }, LIMITE_SEM_TELEMETRIA_MS);
+    } else {
+      setAlertaSemSinal(false);
+    }
+
+    return () => {
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [indicadores, statusCorrida, ultimoTimestampMs]);
+
+  useEffect(() => {
+    if (!bateriaCritica) {
+      bateriaCriticaAbertaRef.current = false;
+      return;
+    }
+
+    if (bateriaCriticaAbertaRef.current) {
+      return;
+    }
+
+    bateriaCriticaAbertaRef.current = true;
+    setAlertaCritico({
+      type: "battery",
+      key: `battery-${ultimoTimestampMs ?? Date.now()}`,
+    });
+  }, [bateriaCritica, ultimoTimestampMs]);
+
+  useEffect(() => {
+    if (!paradaInesperada) {
+      paradaInesperadaAbertaRef.current = false;
+      return;
+    }
+
+    if (paradaInesperadaAbertaRef.current) {
+      return;
+    }
+
+    paradaInesperadaAbertaRef.current = true;
+    setAlertaCritico({
+      type: "stopped",
+      key: `stopped-${ultimoTimestampMs ?? Date.now()}`,
+    });
+  }, [paradaInesperada, ultimoTimestampMs]);
+
   const snapshot = viewMode === "history" ? history[historyIndex] : undefined;
   const displayMaze = snapshot ? snapshot.maze : maze;
   const displayPath = snapshot ? snapshot.path : path;
   const displayPosition = snapshot ? snapshot.endPosition : position;
+  const displayDirection = snapshot ? snapshot.endDirection : direction;
   const displayGridSize = snapshot ? snapshot.gridSize : gridSize;
   const displayGridDimension =
     displayGridSize === 16
@@ -51,7 +166,6 @@ export default function MazeViewer() {
       : displayGridSize === 8
         ? "min(70vmin, 520px)"
         : "min(60vmin, 360px)";
-  const wallShadowColor = "rgb(9 9 11)";
   const origin = { row: 0, col: 0 };
   const rawPathPoints = [origin, ...displayPath];
   if (!positionsEqual(rawPathPoints[rawPathPoints.length - 1], displayPosition)) {
@@ -83,14 +197,6 @@ export default function MazeViewer() {
     setIsHistoryOpen(false);
   };
 
-  const updateGridSize = (size: number) => {
-    if (size === gridSize) {
-      return;
-    }
-
-    resetRunState(size);
-    setGridSize(size);
-  };
 
   const startSession = () => {
     resetRunState(gridSize);
@@ -125,7 +231,8 @@ export default function MazeViewer() {
   }, [direction]);
 
   useEffect(() => {
-    const dimensao = Number(configSessao.dimensao);
+    if (!configSessao?.dimensao) return;
+    const dimensao = parseInt(String(configSessao.dimensao), 10);
     if (
       !Number.isNaN(dimensao) &&
       (dimensao === 4 || dimensao === 8 || dimensao === 16)
@@ -135,7 +242,7 @@ export default function MazeViewer() {
         setGridSize(dimensao);
       }
     }
-  }, [configSessao.dimensao, gridSize]);
+  }, [configSessao?.dimensao, gridSize]);
 
   useEffect(() => {
     if (filaMovimentacoes.length === 0) {
@@ -255,50 +362,453 @@ export default function MazeViewer() {
     setSessionStatus("finished");
   }, [indicadores.status_corrida, gridSize]);
 
+  if (standalone) {
+    return (
+      <div className="min-h-screen bg-[#09090b] text-zinc-100 p-6 font-sans">
+        {/* Modals & Alerts */}
+        <CriticalAlertModal
+          open={alertaCritico !== null}
+          type={alertaCritico?.type}
+          soundKey={alertaCritico?.key ?? null}
+          onDismiss={() => setAlertaCritico(null)}
+          onConfirm={() => setAlertaCritico(null)}
+        />
+
+        {/* Top Header Block */}
+        <header className="mb-6 rounded-3xl border border-yellow-500/20 bg-zinc-900/40 p-6 backdrop-blur-md shadow-lg shadow-yellow-500/5 relative overflow-hidden">
+          <div className="absolute top-0 right-0 w-64 h-64 bg-yellow-500/5 rounded-full blur-3xl pointer-events-none"></div>
+          
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <span className="text-3xl animate-pulse">⚡</span>
+              <div>
+                <h1 className="text-2xl font-bold tracking-wider text-yellow-400 uppercase">
+                  PIKACHU — Mapeamento em Tempo Real
+                </h1>
+                <p className="text-xs text-zinc-400 mt-0.5 tracking-wide">
+                  Micromouse MM-07 Control System
+                </p>
+              </div>
+            </div>
+
+            {/* Status bar */}
+            <div className="flex flex-wrap items-center gap-4 text-sm font-semibold tracking-wide bg-zinc-950/50 border border-zinc-800 rounded-2xl px-5 py-2.5">
+              <div className="flex items-center gap-2">
+                <span className="text-zinc-500">Status:</span>
+                <div className="flex items-center gap-1.5">
+                  <span className={`h-2.5 w-2.5 rounded-full ${statusConexao === "online" ? "bg-emerald-500 animate-pulse" : "bg-rose-500"}`} />
+                  <span className={statusConexao === "online" ? "text-emerald-400" : "text-rose-400"}>
+                    {statusConexao === "online" ? "Online" : statusConexao === "offline" ? "Offline" : "Conectando..."}
+                  </span>
+                </div>
+              </div>
+
+              <div className="h-4 w-px bg-zinc-800" />
+
+              <div className="flex items-center gap-2">
+                <span className="text-zinc-500">Modo:</span>
+                <span className="text-yellow-400">
+                  {viewMode === "history"
+                    ? "Histórico"
+                    : sessionStatus === "finished"
+                      ? "Finalizado"
+                      : sessionStatus === "running"
+                        ? "Mapeamento"
+                        : "Aguardando"}
+                </span>
+              </div>
+
+              <div className="h-4 w-px bg-zinc-800" />
+
+              <div className="flex items-center gap-2">
+                <span className="text-zinc-500">Corrida:</span>
+                <span className="text-zinc-300">
+                  {indicadores.id_corrida_banco ? `#${indicadores.id_corrida_banco}` : "Atual"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        {/* Warning banners */}
+        <div className="mb-6 space-y-3">
+          {bateriaCritica && (
+            <div className="rounded-2xl border border-rose-500/20 bg-rose-500/10 px-5 py-3.5 text-sm font-semibold text-rose-300 flex items-center gap-2 animate-pulse">
+              ⚠️ Bateria crítica: nível em {bateriaAtual?.toFixed(1)}% ou menos. Ação imediata necessária.
+            </div>
+          )}
+
+          {alertaSemSinal && (
+            <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-5 py-3.5 text-sm font-semibold text-amber-300 flex items-center gap-2">
+              ⚠️ Ausência de telemetria recente: sem novos pacotes de movimentação há mais de 3 segundos.
+            </div>
+          )}
+        </div>
+
+        {/* Main Grid area */}
+        <div className="flex flex-col gap-6 lg:flex-row">
+          {/* Left Column: Maze & Legend */}
+          <div className="flex-1 flex flex-col gap-6 rounded-3xl border border-zinc-800 bg-zinc-900/20 p-6 backdrop-blur-md">
+            <div className="flex items-center justify-between border-b border-zinc-800 pb-4">
+              <h2 className="text-lg font-semibold tracking-wide text-yellow-400">
+                Arena / Labirinto
+              </h2>
+
+              {/* Quick Actions */}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={startSession}
+                  className="rounded-xl bg-yellow-400 hover:bg-yellow-500 active:bg-yellow-600 text-zinc-950 font-bold px-4 py-2 text-xs transition duration-155 shadow-md shadow-yellow-500/10 cursor-pointer"
+                >
+                  Limpar Mapa
+                </button>
+                <button
+                  type="button"
+                  onClick={openHistory}
+                  className="rounded-xl border border-zinc-700 bg-zinc-800/80 hover:bg-zinc-850 text-zinc-300 hover:text-white px-4 py-2 text-xs transition duration-150 cursor-pointer"
+                >
+                  Histórico
+                </button>
+
+
+              </div>
+            </div>
+
+            {/* Maze Center Wrapper */}
+            <div className="flex justify-center items-center py-6 bg-zinc-950/20 rounded-2xl border border-zinc-800/50">
+              <div
+                className="relative grid select-none"
+                style={{
+                  gridTemplateColumns: `repeat(${displayGridSize}, minmax(0, 1fr))`,
+                  width: displayGridDimension,
+                  height: displayGridDimension,
+                }}
+              >
+                {displayMaze.map((row, rowIndex) =>
+                  row.map((cell, colIndex) => {
+                    const cellPosition = { row: rowIndex, col: colIndex };
+                    const isCurrent = positionsEqual(
+                      cellPosition,
+                      displayPosition,
+                    );
+                    const isOnPath = displayPath.some((step) =>
+                      positionsEqual(step, cellPosition),
+                    );
+                    const isGoal = goalAreaCells.some((goalCell) => 
+                      positionsEqual(goalCell, cellPosition)
+                    );
+                    
+                    const backgroundColor = isCurrent
+                      ? "rgb(125 211 252)"
+                      : isGoal
+                        ? "rgb(34 197 94)"
+                        : cell.visited
+                          ? "rgb(30 41 59)"
+                          : isOnPath
+                            ? "rgb(15 23 42)"
+                            : "rgb(9 9 11)";
+                    const wallShadows = [
+                      cell.walls.north
+                        ? `inset 0 2px 0 0 rgb(234 179 8)`
+                        : null,
+                      cell.walls.south
+                        ? `inset 0 -2px 0 0 rgb(234 179 8)`
+                        : null,
+                      cell.walls.east
+                        ? `inset -2px 0 0 0 rgb(234 179 8)`
+                        : null,
+                      cell.walls.west
+                        ? `inset 2px 0 0 0 rgb(234 179 8)`
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(", ");
+                    const classes = [
+                      "relative aspect-square border border-zinc-850",
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+
+                    return (
+                      <div
+                        key={`${rowIndex}-${colIndex}`}
+                        className={`z-20 ${classes}`}
+                        style={{
+                          backgroundColor,
+                          boxShadow: wallShadows || undefined,
+                        }}
+                      />
+                    );
+                  }),
+                )}
+                {/* SVG path points */}
+                <svg
+                  className="pointer-events-none absolute inset-0 z-20 h-full w-full"
+                  viewBox={`0 0 ${displayGridSize} ${displayGridSize}`}
+                  aria-hidden="true"
+                >
+                  <polyline
+                    points={pathPointsString}
+                    fill="none"
+                    stroke="#a855f7"
+                    strokeWidth="0.04"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="opacity-75"
+                  />
+                </svg>
+                {/* Pikachu sprite */}
+                <img
+                  src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
+                  alt="Pikachu Micromouse"
+                  className="pointer-events-none absolute z-30 object-contain"
+                  style={{
+                    width: `${120 / displayGridSize}%`,
+                    height: `${120 / displayGridSize}%`,
+                    left: `${((displayPosition.col + 0.5) / displayGridSize) * 100}%`,
+                    top: `${((displayPosition.row + 0.5) / displayGridSize) * 100}%`,
+                    transform: "translate(-50%, -50%)",
+                    filter: "drop-shadow(0px 2px 4px rgba(250,204,21,0.5))"
+                  }}
+                />
+              </div>
+            </div>
+
+            {/* Legend Panel */}
+            <footer className="mt-2 pt-4 border-t border-zinc-800 flex flex-wrap gap-x-6 gap-y-3 justify-center text-xs font-semibold tracking-wide text-zinc-400">
+              <span className="text-zinc-500 uppercase mr-1">Legenda:</span>
+              <div className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 rounded bg-[rgb(30,41,59)] border border-zinc-700" />
+                <span>Visitada</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 rounded bg-[rgb(34,197,94)] border border-green-500" />
+                <span>Mapeada (Objetivo 2x2)</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 rounded bg-transparent border border-zinc-800 shadow-[inset_0_2px_0_0_rgb(234,179,8)]" />
+                <span>Parede Detectada</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="h-1 w-3 bg-[#a855f7] rounded-full" />
+                <span>Rastro</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <img
+                  src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
+                  alt="Pikachu Icon"
+                  className="h-5 w-5 object-contain"
+                />
+                <span>Pikachu (Atual)</span>
+              </div>
+            </footer>
+          </div>
+
+          {/* Right Column: Telemetry */}
+          <div className="w-full lg:w-96 flex flex-col gap-6">
+            <section className="rounded-3xl border border-zinc-800 bg-zinc-900/20 p-6 backdrop-blur-md shadow-lg flex-1">
+              <h2 className="text-lg font-semibold tracking-wide text-yellow-400 border-b border-zinc-800 pb-4">
+                Telemetria
+              </h2>
+
+              <div className="mt-6 space-y-6">
+                {/* Posicao Card */}
+                <div className="bg-zinc-950/40 border border-zinc-800/80 rounded-2xl p-5 relative overflow-hidden">
+                  <span className="absolute right-4 top-4 text-2xl text-zinc-700">🎯</span>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    Posição Atual
+                  </p>
+                  <p className="mt-2 text-3xl font-extrabold tracking-tight text-white font-mono">
+                    ({displayPosition.col}, {displayPosition.row})
+                  </p>
+                </div>
+
+                {/* Direcao Card */}
+                <div className="bg-zinc-950/40 border border-zinc-800/80 rounded-2xl p-5 relative overflow-hidden">
+                  <span className="absolute right-4 top-4 text-2xl text-zinc-700">🧭</span>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    Direção
+                  </p>
+                  <p className="mt-2 text-2xl font-extrabold tracking-tight text-white uppercase">
+                    {displayDirection === "north"
+                      ? "Norte (↑)"
+                      : displayDirection === "south"
+                        ? "Sul (↓)"
+                        : displayDirection === "east"
+                          ? "Leste (→)"
+                          : "Oeste (←)"}
+                  </p>
+                </div>
+
+                {/* Bateria Card */}
+                <div className="bg-zinc-950/40 border border-zinc-800/80 rounded-2xl p-5 relative overflow-hidden">
+                  <span className="absolute right-4 top-4 text-2xl text-zinc-700">⚡</span>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    Nível de Bateria
+                  </p>
+                  <div className="mt-2 flex items-baseline gap-2">
+                    <span className="text-3xl font-extrabold tracking-tight text-white font-mono">
+                      {bateriaAtual !== null ? `${bateriaAtual.toFixed(1)}%` : "--%"}
+                    </span>
+                    {bateriaCritica && (
+                      <span className="text-xs text-rose-400 font-bold animate-pulse">
+                        [CRÍTICA]
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 w-full bg-zinc-800 rounded-full h-2">
+                    <div
+                      className={`h-2 rounded-full transition-all duration-300 ${
+                        bateriaCritica
+                          ? "bg-rose-500"
+                          : bateriaAtual !== null && bateriaAtual <= 50
+                            ? "bg-yellow-500"
+                            : "bg-emerald-500"
+                      }`}
+                      style={{ width: `${bateriaAtual ?? 0}%` }}
+                    />
+                  </div>
+                </div>
+
+                {/* Tempo Card */}
+                <div className="bg-zinc-950/40 border border-zinc-800/80 rounded-2xl p-5 relative overflow-hidden">
+                  <span className="absolute right-4 top-4 text-2xl text-zinc-700">⏱️</span>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    Tempo Decorrido
+                  </p>
+                  <p className="mt-2 text-3xl font-extrabold tracking-tight text-white font-mono">
+                    {formatarTempo(tempoExibido)}
+                  </p>
+                  <p className="mt-1 text-[10px] text-zinc-500 leading-none">
+                    {sessionStatus === "finished"
+                      ? "Tempo fixado de corrida concluída"
+                      : "Atualizado em tempo real"}
+                  </p>
+                </div>
+
+                {/* Velocidade Card */}
+                <div className="bg-zinc-950/40 border border-zinc-800/80 rounded-2xl p-5 relative overflow-hidden">
+                  <span className="absolute right-4 top-4 text-2xl text-zinc-700">📈</span>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    Velocidade Média
+                  </p>
+                  <p className="mt-2 text-2xl font-extrabold tracking-tight text-white font-mono">
+                    {velocidadeMedia !== null ? `${velocidadeMedia.toFixed(2)} cm/s` : "-- cm/s"}
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        {/* History Modal */}
+        {isHistoryOpen && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="w-full max-w-lg rounded-3xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+              <div className="flex items-center justify-between border-b border-zinc-800 pb-3">
+                <h2 className="text-lg font-bold text-yellow-400 uppercase tracking-wide">
+                  Histórico de Corridas
+                </h2>
+                <button
+                  type="button"
+                  onClick={() => setIsHistoryOpen(false)}
+                  className="rounded-xl p-1.5 hover:bg-zinc-800 text-zinc-400 hover:text-white cursor-pointer"
+                >
+                  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+
+              <div className="mt-4 space-y-3 max-h-[320px] overflow-y-auto pr-1">
+                {history.map((run, idx) => (
+                  <button
+                    key={`history-${idx}`}
+                    type="button"
+                    className={`w-full flex items-center justify-between p-4 rounded-2xl border transition duration-150 cursor-pointer ${
+                      viewMode === "history" && historyIndex === idx
+                        ? "border-yellow-400 bg-yellow-400/5 text-white"
+                        : "border-zinc-800 bg-zinc-950/40 text-zinc-300 hover:border-zinc-700"
+                    }`}
+                    onClick={() => selectHistory(idx)}
+                  >
+                    <div className="text-left">
+                      <p className="font-semibold text-sm">Corrida #{history.length - idx}</p>
+                      <p className="text-xs text-zinc-500">
+                        Tamanho da grade: {run.gridSize}x{run.gridSize} · {run.path.length} passos
+                      </p>
+                    </div>
+                    <span className="text-xs font-bold text-yellow-400">Ver Trajeto</span>
+                  </button>
+                ))}
+                {history.length === 0 && (
+                  <p className="rounded-xl border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-500">
+                    Nenhuma corrida registrada ainda.
+                  </p>
+                )}
+              </div>
+
+              {viewMode === "history" && (
+                <button
+                  type="button"
+                  className="mt-6 w-full py-3.5 rounded-2xl bg-yellow-400 hover:bg-yellow-500 text-zinc-950 font-bold transition duration-150 cursor-pointer"
+                  onClick={() => {
+                    setViewMode("live");
+                    setIsHistoryOpen(false);
+                  }}
+                >
+                  Voltar para tempo real
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-      <header className="flex flex-col gap-4 border-b border-zinc-100 pb-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
-            Labirinto
-          </p>
-          <h2 className="text-xl font-semibold text-zinc-950">
-            Mapa de navegacao em tempo real
-          </h2>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="rounded-lg bg-zinc-950 px-3 py-2 text-xs font-semibold text-white transition hover:bg-zinc-800"
-            onClick={startSession}
-          >
-            Limpar mapa
-          </button>
-          <button
-            type="button"
-            className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50"
-            onClick={openHistory}
-          >
-            Historico
-          </button>
-          {GRID_SIZES.map((size) => (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-950 p-6 shadow-sm text-zinc-100">
+      {showHeader && (
+        <header className="flex flex-col gap-4 border-b border-zinc-805 pb-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+              Labirinto
+            </p>
+            <h2 className="text-xl font-bold text-yellow-400">
+              Mapa de navegação em tempo real
+            </h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
             <button
-              key={size}
               type="button"
-              className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50"
-              onClick={() => updateGridSize(size)}
+              className="rounded-lg bg-yellow-400 hover:bg-yellow-500 text-zinc-950 px-3 py-2 text-xs font-bold transition duration-150 cursor-pointer"
+              onClick={startSession}
             >
-              {size}x{size}
+              Limpar mapa
             </button>
-          ))}
-        </div>
-      </header>
+            <button
+              type="button"
+              className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-bold text-zinc-300 hover:text-white transition hover:bg-zinc-700 cursor-pointer"
+              onClick={openHistory}
+            >
+              Histórico
+            </button>
+
+          </div>
+        </header>
+      )}
 
       <div className="mt-6 flex flex-col gap-6 lg:flex-row">
         <div className="flex-1">
-          <div className="relative rounded-2xl border border-zinc-200 bg-zinc-50 p-3">
+          <div className="relative rounded-2xl border border-zinc-800 bg-zinc-900/20 p-3">
             <div
-              className="relative grid"
+              className="relative grid mx-auto"
               style={{
                 gridTemplateColumns: `repeat(${displayGridSize}, minmax(0, 1fr))`,
                 width: displayGridDimension,
@@ -322,30 +832,30 @@ export default function MazeViewer() {
                   const backgroundColor = isCurrent
                     ? "rgb(125 211 252)"
                     : isGoal
-                      ? "rgb(250 204 21)" // amarelo forte para destacar bem o objetivo
+                      ? "rgb(34 197 94)" // verde vibrante para destacar do amarelo das paredes
                       : cell.visited
-                        ? "rgb(186 230 253)"
+                        ? "rgb(30 41 59)"
                         : isOnPath
-                          ? "rgb(224 242 254)"
-                          : "rgb(255 255 255)";
+                          ? "rgb(15 23 42)"
+                          : "rgb(9 9 11)";
                   const wallShadows = [
                     cell.walls.north
-                      ? `inset 0 2px 0 0 ${wallShadowColor}`
+                      ? `inset 0 2px 0 0 rgb(234 179 8)`
                       : null,
                     cell.walls.south
-                      ? `inset 0 -2px 0 0 ${wallShadowColor}`
+                      ? `inset 0 -2px 0 0 rgb(234 179 8)`
                       : null,
                     cell.walls.east
-                      ? `inset -2px 0 0 0 ${wallShadowColor}`
+                      ? `inset -2px 0 0 0 rgb(234 179 8)`
                       : null,
                     cell.walls.west
-                      ? `inset 2px 0 0 0 ${wallShadowColor}`
+                      ? `inset 2px 0 0 0 rgb(234 179 8)`
                       : null,
                   ]
                     .filter(Boolean)
                     .join(", ");
                   const classes = [
-                    "relative aspect-square border border-zinc-200",
+                    "relative aspect-square border border-zinc-900",
                   ]
                     .filter(Boolean)
                     .join(" ");
@@ -370,10 +880,11 @@ export default function MazeViewer() {
                 <polyline
                   points={pathPointsString}
                   fill="none"
-                  stroke="rgb(37 99 235)"
+                  stroke="#a855f7"
                   strokeWidth="0.04"
                   strokeLinecap="round"
                   strokeLinejoin="round"
+                  className="opacity-75"
                 />
               </svg>
               <img
@@ -386,88 +897,119 @@ export default function MazeViewer() {
                   left: `${((displayPosition.col + 0.5) / displayGridSize) * 100}%`,
                   top: `${((displayPosition.row + 0.5) / displayGridSize) * 100}%`,
                   transform: "translate(-50%, -50%)",
-                  filter: "drop-shadow(0px 2px 3px rgba(0,0,0,0.4))"
+                  filter: "drop-shadow(0px 2px 4px rgba(250,204,21,0.5))"
                 }}
               />
             </div>
           </div>
-        </div>
 
-        <aside className="w-full lg:w-72">
-          <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
-              Status da corrida
-            </p>
-            <div className="mt-3 space-y-2 text-sm text-zinc-700">
-              <p className="flex items-center justify-between">
-                <span>Sessao</span>
-                <span className="font-semibold text-zinc-900">
-                  {sessionStatus}
-                </span>
-              </p>
-              <p className="flex items-center justify-between">
-                <span>Conexao</span>
-                <span className="font-semibold text-zinc-900">
-                  {statusConexao}
-                </span>
-              </p>
-              <p className="flex items-center justify-between">
-                <span>Posicao</span>
-                <span className="font-semibold text-zinc-900">
-                  ({displayPosition.row}, {displayPosition.col})
-                </span>
-              </p>
-              <p className="flex items-center justify-between">
-                <span>Grade</span>
-                <span className="font-semibold text-zinc-900">
-                  {displayGridSize}x{displayGridSize}
-                </span>
-              </p>
+          {/* Legenda */}
+          <div className="mt-4 pt-4 border-t border-zinc-800 flex flex-wrap gap-x-6 gap-y-3 justify-center text-xs font-semibold text-zinc-400">
+            <span className="text-zinc-500 uppercase mr-1">Legenda:</span>
+            <div className="flex items-center gap-2">
+              <span className="h-3.5 w-3.5 rounded bg-[rgb(30,41,59)] border border-zinc-700" />
+              <span>Visitada</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="h-3.5 w-3.5 rounded bg-[rgb(34,197,94)] border border-green-500" />
+              <span>Mapeada (Objetivo 2x2)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="h-3.5 w-3.5 rounded bg-transparent border border-zinc-800 shadow-[inset_0_2px_0_0_rgb(234,179,8)]" />
+              <span>Parede Detectada</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="h-1 w-3 bg-[#a855f7] rounded-full" />
+              <span>Rastro</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <img
+                src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
+                alt="Pikachu Icon"
+                className="h-5 w-5 object-contain"
+              />
+              <span>Pikachu (Atual)</span>
             </div>
           </div>
-        </aside>
+        </div>
+
+        {showSidebar && (
+          <aside className="w-full lg:w-72">
+            <div className="rounded-2xl border border-zinc-800 bg-zinc-950 p-4 shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                Status da corrida
+              </p>
+              <div className="mt-3 space-y-2 text-sm text-zinc-400">
+                <p className="flex items-center justify-between">
+                  <span>Sessao</span>
+                  <span className="font-semibold text-zinc-200">
+                    {sessionStatus}
+                  </span>
+                </p>
+                <p className="flex items-center justify-between">
+                  <span>Conexao</span>
+                  <span className="font-semibold text-zinc-200">
+                    {statusConexao}
+                  </span>
+                </p>
+                <p className="flex items-center justify-between">
+                  <span>Posicao</span>
+                  <span className="font-semibold text-zinc-200">
+                    ({displayPosition.row}, {displayPosition.col})
+                  </span>
+                </p>
+                <p className="flex items-center justify-between">
+                  <span>Grade</span>
+                  <span className="font-semibold text-zinc-200">
+                    {displayGridSize}x{displayGridSize}
+                  </span>
+                </p>
+              </div>
+            </div>
+          </aside>
+        )}
       </div>
 
       {isHistoryOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/40 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-955/60 p-4 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
         >
-          <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
-            <div className="flex items-center justify-between border-b border-zinc-100 pb-3">
-              <h2 className="text-lg font-semibold text-zinc-900">
-                Historico de Corridas
+          <div className="w-full max-w-lg rounded-2xl bg-zinc-900 border border-zinc-800 p-6 shadow-xl text-zinc-100">
+            <div className="flex items-center justify-between border-b border-zinc-800 pb-3">
+              <h2 className="text-lg font-bold text-yellow-400">
+                Histórico de Corridas
               </h2>
               <button
                 type="button"
-                className="rounded-lg border border-zinc-200 px-3 py-1.5 text-sm text-zinc-600 transition hover:bg-zinc-50"
+                className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-300 hover:text-white transition hover:bg-zinc-700 cursor-pointer"
                 onClick={() => setIsHistoryOpen(false)}
               >
                 Fechar
               </button>
             </div>
-            <div className="mt-4 space-y-2">
+            <div className="mt-4 space-y-2 max-h-[60vh] overflow-y-auto pr-1">
               {history.map((run, index) => (
                 <button
                   key={`history-${index}`}
                   type="button"
-                  className="flex w-full items-center justify-between rounded-xl border border-zinc-200 px-4 py-3 text-left text-sm text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50"
+                  className="flex w-full items-center justify-between rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 text-left text-sm text-zinc-300 transition hover:border-zinc-700 hover:bg-zinc-900 cursor-pointer"
                   onClick={() => selectHistory(index)}
                 >
                   <div>
-                    <span className="block text-sm font-semibold text-zinc-900">
+                    <span className="block text-sm font-semibold text-zinc-100">
                       Corrida {index + 1}
                     </span>
                     <span className="text-xs text-zinc-500">
                       {run.gridSize}x{run.gridSize} · {run.path.length} passos
                     </span>
                   </div>
-                  <span className="text-lg text-zinc-400">→</span>
+                  <span className="text-lg text-zinc-600">→</span>
                 </button>
               ))}
               {history.length === 0 && (
-                <p className="rounded-xl border border-dashed border-zinc-200 px-4 py-6 text-center text-sm text-zinc-500">
+                <p className="rounded-xl border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-500">
                   Nenhuma corrida registrada ainda.
                 </p>
               )}

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1,1 +1,28 @@
 @import "tailwindcss";
+
+@theme {
+  /* Cores de Marca (Brand Colors) */
+  --color-primary: var(--color-yellow-400);
+  --color-primary-hover: var(--color-yellow-500);
+  --color-primary-active: var(--color-yellow-600);
+  
+  --color-secondary: #a855f7; /* Roxo para trajetos */
+  --color-secondary-hover: var(--color-purple-600);
+  
+  --color-tertiary: var(--color-emerald-500); /* Verde para objetivos */
+  
+  /* Cores Semânticas de Estado */
+  --color-success: var(--color-emerald-500);
+  --color-danger: var(--color-rose-500);
+  --color-warning: var(--color-amber-500);
+  --color-info: var(--color-sky-400);
+  
+  /* Cores de Fundo e Superfície (Dark Theme) */
+  --color-background: var(--color-zinc-950);
+  --color-surface: var(--color-zinc-900);
+  --color-surface-hover: var(--color-zinc-800);
+  
+  /* Bordas e Linhas */
+  --color-border: var(--color-zinc-800);
+  --color-border-focus: var(--color-zinc-700);
+}

--- a/src/frontend/src/pages/LabirintoPage.tsx
+++ b/src/frontend/src/pages/LabirintoPage.tsx
@@ -27,8 +27,8 @@ export function LabirintoPage({
       eyebrow="Labirinto"
       title="Mapa do labirinto em tempo real"
       description="Visualize paredes detectadas, percurso e posicao atual do Micromouse."
-      statusConexao={statusConexao}
-      mensagemStatusConexao={mensagemStatusConexao}
+      statusConexao={telemetria.statusConexao}
+      mensagemStatusConexao={telemetria.mensagemStatusConexao}
     >
       <div className="flex flex-col gap-4 max-w-[1600px] mx-auto w-full">
         {/* Top compact indicators */}

--- a/src/frontend/src/pages/LabirintoPage.tsx
+++ b/src/frontend/src/pages/LabirintoPage.tsx
@@ -1,4 +1,5 @@
 import MazeViewer from "../components/maze/MazeViewer";
+import { TopIndicators, ControlPanel, TelemetryAlerts } from "../components/DashboardIndicadores";
 import { MonitoringLayout } from "../components/MonitoringLayout";
 import { useTelemetria } from "../hooks/useTelemetria";
 
@@ -13,20 +14,37 @@ export function LabirintoPage({
   onNavigateTelemetria,
   onNavigateLabirinto,
 }: LabirintoPageProps) {
-  const { statusConexao, mensagemStatusConexao } = useTelemetria();
+  const telemetria = useTelemetria();
 
   return (
     <MonitoringLayout
       activeView={activeView}
       onNavigateTelemetria={onNavigateTelemetria}
       onNavigateLabirinto={onNavigateLabirinto}
-      eyebrow="Labirinto"
-      title="Mapa do labirinto em tempo real"
-      description="Visualize paredes detectadas, percurso e posicao atual do Micromouse."
-      statusConexao={statusConexao}
-      mensagemStatusConexao={mensagemStatusConexao}
+      eyebrow="Monitoramento"
+      title="Micromouse"
+      description="Painel de Controle Integrado em Tempo Real"
+      statusConexao={telemetria.statusConexao}
+      mensagemStatusConexao={telemetria.mensagemStatusConexao}
     >
-      <MazeViewer />
+      <div className="flex flex-col gap-4 max-w-[1600px] mx-auto w-full">
+        {/* Top compact indicators */}
+        <TopIndicators telemetria={telemetria} />
+
+        {/* Alerts if any */}
+        <TelemetryAlerts telemetria={telemetria} />
+
+        {/* Main Grid: Control Panel + Maze */}
+        <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
+          <div className="w-full lg:w-48 xl:w-56 flex-shrink-0">
+            <ControlPanel telemetria={telemetria} />
+          </div>
+
+          <div className="flex-1 w-full flex flex-col justify-center items-center rounded-2xl bg-zinc-900/30 border border-zinc-800/80 p-4 lg:p-6 shadow-sm overflow-hidden">
+            <MazeViewer showHeader={false} showSidebar={false} standalone={false} />
+          </div>
+        </div>
+      </div>
     </MonitoringLayout>
   );
 }

--- a/src/frontend/src/pages/TelemetriaPage.tsx
+++ b/src/frontend/src/pages/TelemetriaPage.tsx
@@ -1,9 +1,10 @@
-import { DashboardIndicadores } from '../components/DashboardIndicadores';
-import { MonitoringLayout } from '../components/MonitoringLayout';
-import { useTelemetria } from '../hooks/useTelemetria';
+import MazeViewer from "../components/maze/MazeViewer";
+import { TopIndicators, ControlPanel, TelemetryAlerts } from "../components/DashboardIndicadores";
+import { MonitoringLayout } from "../components/MonitoringLayout";
+import { useTelemetria } from "../hooks/useTelemetria";
 
 type TelemetriaPageProps = {
-  activeView: 'telemetria' | 'labirinto';
+  activeView: "telemetria" | "labirinto";
   onNavigateTelemetria: () => void;
   onNavigateLabirinto: () => void;
 };
@@ -20,13 +21,30 @@ export function TelemetriaPage({
       activeView={activeView}
       onNavigateTelemetria={onNavigateTelemetria}
       onNavigateLabirinto={onNavigateLabirinto}
-      eyebrow="Telemetria"
-      title="Métricas em tempo real do robô MM-07"
-      description="Acompanhe os indicadores exigidos para avaliação da corrida: bateria, velocidade média e tempo de execução."
+      eyebrow="Monitoramento"
+      title="Micromouse"
+      description="Painel de Controle Integrado em Tempo Real"
       statusConexao={telemetria.statusConexao}
       mensagemStatusConexao={telemetria.mensagemStatusConexao}
     >
-      <DashboardIndicadores telemetria={telemetria} />
+      <div className="flex flex-col gap-4 max-w-[1600px] mx-auto w-full">
+        {/* Top compact indicators */}
+        <TopIndicators telemetria={telemetria} />
+
+        {/* Alerts if any */}
+        <TelemetryAlerts telemetria={telemetria} />
+
+        {/* Main Grid: Control Panel + Maze */}
+        <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
+          <div className="w-full lg:w-48 xl:w-56 flex-shrink-0">
+            <ControlPanel telemetria={telemetria} />
+          </div>
+
+          <div className="flex-1 w-full flex flex-col justify-center items-center rounded-2xl bg-zinc-900/30 border border-zinc-800/80 p-4 lg:p-6 shadow-sm overflow-hidden">
+            <MazeViewer showHeader={false} showSidebar={false} standalone={false} />
+          </div>
+        </div>
+      </div>
     </MonitoringLayout>
   );
 }

--- a/src/frontend/src/services/corrida.ts
+++ b/src/frontend/src/services/corrida.ts
@@ -1,6 +1,5 @@
 import type {
   CorridaDetailResponse,
-  CorridaResponse,
   CorridaResumoResponse,
   TipoLabirinto,
 } from "../types/corrida";


### PR DESCRIPTION

## Descrição
Este Pull Request implementa uma refatoração abrangente no frontend para o **Dashboard do Micromouse**. O objetivo principal foi consolidar a telemetria e o labirinto em uma única tela fluída, criar um padrão de cores globais reutilizável (Tailwind v4) e aplicar um tema Dark consistente na aplicação, otimizando o espaço da tela para o monitoramento em tempo real da **US-12 (Exibição do Labirinto)**.

##  O que foi feito?

### 1.  Sistema de Design e Cores Globais (`index.css`)
- Implementação da paleta de cores semânticas via diretiva `@theme` nativa do Tailwind v4 (`--color-primary`, `--color-secondary`, `--color-background`, `--color-surface`, etc.).
- Com essa alteração, basta mudar o `index.css` para alterar a cor do projeto inteiro de forma instantânea, sem precisar reescrever as classes em cada componente.

### 2.  Consolidação e Reestruturação de Layout
- **Integração Labirinto + Telemetria**: Ambos agora residem harmoniosamente na mesma página.
- **`MonitoringLayout.tsx`**: O menu lateral (sidebar) agora inicia **recolhido por padrão** e possui posicionamento estático à tela (`sticky`), não sendo ocultado ao realizar *scroll* no mapa. 
- O botão de alternância do menu agora cobre toda a área superior esquerda, com o ícone vetorial de raio na cor primária (amarelo).
- Modificado o componente modular de `DashboardIndicadores.tsx` dividindo-o em fragmentos menores para otimizar espaço (`TopIndicators`, `ControlPanel` e `TelemetryAlerts`).

### 3. Reestilização da Tela de Sessão (`Session.tsx`)
- Completamente migrada do tema claro (slate-50) para o padrão de **Dark Mode** do projeto (`bg-background` e `bg-surface`).
- O emoji antigo de robô (🤖) foi substituído por um ícone vetorial do Raio (⚡) responsivo e integrado com a classe `text-primary`.

### 4.  Correções Críticas no Mapa (`MazeViewer.tsx`)
- **Automação de Dimensões**: Corrigido o bug na conversão de string ("16x16") para número (16), fazendo com que a grade seja renderizada dinamicamente com base apenas nas configurações da sessão vindas do Backend, dispensando intervenção manual.
- Estilização do trajeto ortogonal do Micromouse padronizado para uso da cor `--color-secondary` (Roxo).

## 🧪 Como testar?
1. Inicie os containers com `docker compose up --build`.
2. No frontend, verifique se a tela `Aguardando Inicialização` está exibindo o modo escuro com o ícone do raio.
3. Utilize o script de simulação: `./simulate_maze.sh --size 16 --delay 0.2` para iniciar os envios de pacotes de telemetria falsos.
4. Confirme que:
   - A barra lateral de navegação não rola em conjunto com a página inteira.
   - As métricas vitais estão num container condensado na parte superior.
   - O grid se adapta perfeitamente ao tamanho recebido (e não fica fixo em 8x8).
   - Testes com `npm run test` continuam rodando 100%.
