### PR TITLE
[US-17]:.Visualização do Melhor Resultado por Labirinto

### DIFF
--- a/src/backend/app/routers/corridas.py
+++ b/src/backend/app/routers/corridas.py
@@ -1,7 +1,7 @@
 """Router de Corridas — registro e consulta."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlmodel import Session, select
+from sqlmodel import Session, select,  func
 
 from ..database import get_session
 from ..models.corrida import Corrida
@@ -125,6 +125,38 @@ def listar_corridas(
 
     results = session.exec(statement).all()
     return [_to_response_resumed(corrida, tipo_lab) for corrida, tipo_lab in results]
+
+@router.get(
+    "/melhor-tempo",
+    response_model=CorridaResponse,
+    summary="Melhor tempo por tipo de labirinto",
+)
+def melhor_tempo(
+    tipo: TipoLabirinto = Query(
+        description="Tipo de labirinto (4X4, 8X8, 16X16).",
+    ),
+    session: Session = Depends(get_session),
+) -> CorridaResponse:
+    """Retorna a corrida com menor tempo_total onde desafio_cumprido=True
+    para o tipo de labirinto informado.
+    """
+    statement = (
+        select(Corrida, Labirinto.tipo_labirinto)
+        .join(Labirinto, Corrida.id_labirinto == Labirinto.id_labirinto)
+        .where(Labirinto.tipo_labirinto == tipo)
+        .where(Corrida.desafio_cumprido == True)
+        .where(Corrida.tempo_total.isnot(None))
+        .order_by(Corrida.tempo_total.asc())
+        .limit(1)
+    )
+
+    result = session.exec(statement).first()
+
+    if result is None:
+        raise HTTPException(status_code=404, detail="Nenhum desafio concluído ainda.")
+
+    corrida, tipo_lab = result
+    return _to_response(corrida, tipo_lab)
 
 
 @router.get(

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -2,48 +2,41 @@ import { useState } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { LabirintoPage } from './pages/LabirintoPage';
 import { TelemetriaPage } from './pages/TelemetriaPage';
-import { CorridasPage } from './pages/CorridaPage';
+import { SessionsPage } from './pages/SessionsPage';
 import Session from './components/Session';
 
 function App() {
   const [currentView, setCurrentView] = useState<'session' | 'telemetria' | 'labirinto' | 'corridas'>('session');
 
   return (
-  <main className="app">
-    <Toaster position="top-right" />
-
-    {currentView === 'session' && (
-      <Session onNavigate={() => setCurrentView('telemetria')} />
-    )}
-
-    {currentView === 'telemetria' && (
-      <TelemetriaPage
-        activeView={currentView}
-        onNavigateTelemetria={() => setCurrentView('telemetria')}
-        onNavigateLabirinto={() => setCurrentView('labirinto')}
-        onNavigateCorridas={() => setCurrentView('corridas')}
-      />
-    )}
-
-    {currentView === 'labirinto' && (
-      <LabirintoPage
-        activeView={currentView}
-        onNavigateTelemetria={() => setCurrentView('telemetria')}
-        onNavigateLabirinto={() => setCurrentView('labirinto')}
-        onNavigateCorridas={() => setCurrentView('corridas')}
-      />
-    )}
-
-    {currentView === 'corridas' && (
-      <CorridasPage
-        activeView={currentView}
-        onNavigateTelemetria={() => setCurrentView('telemetria')}
-        onNavigateLabirinto={() => setCurrentView('labirinto')}
-        onNavigateCorridas={() => setCurrentView('corridas')}
-      />
-    )}
-  </main>
-);
+    <main className="app">
+      <Toaster position="top-right" />
+      {currentView === 'session' ? (
+        <Session onNavigate={() => setCurrentView('telemetria')} />
+      ) : currentView === 'telemetria' ? (
+        <TelemetriaPage
+          activeView={currentView}
+          onNavigateTelemetria={() => setCurrentView('telemetria')}
+          onNavigateLabirinto={() => setCurrentView('labirinto')}
+          onNavigateCorridas={() => setCurrentView('corridas')}
+        />
+      ) : currentView === 'labirinto' ? (
+        <LabirintoPage
+          activeView={currentView}
+          onNavigateTelemetria={() => setCurrentView('telemetria')}
+          onNavigateLabirinto={() => setCurrentView('labirinto')}
+          onNavigateCorridas={() => setCurrentView('corridas')}
+        />
+      ) : (
+        <SessionsPage
+          activeView={currentView}
+          onNavigateTelemetria={() => setCurrentView('telemetria')}
+          onNavigateLabirinto={() => setCurrentView('labirinto')}
+          onNavigateCorridas={() => setCurrentView('corridas')}
+        />
+      )}
+    </main>
+  );
 }
 
 export default App;

--- a/src/frontend/src/__tests__/integration/CardMelhorTempo.integration.test.tsx
+++ b/src/frontend/src/__tests__/integration/CardMelhorTempo.integration.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CardMelhorTempo } from "../../components/CardMelhorTempo";
+import type { MelhorTempoResponse } from "../../types/corrida";
+
+// ---------------------------------------------------------------------------
+// Mock do service (camada de integração real: hook → service mockado)
+// ---------------------------------------------------------------------------
+
+vi.mock("../../services/corrida", () => ({
+  fetchMelhorTempo: vi.fn(),
+  listarCorridasResumo: vi.fn(),
+  obterCorrida: vi.fn(),
+}));
+
+import { fetchMelhorTempo } from "../../services/corrida";
+const mockFetchMelhorTempo = vi.mocked(fetchMelhorTempo);
+
+// ---------------------------------------------------------------------------
+// Dados de teste
+// ---------------------------------------------------------------------------
+
+const mockRecorde: MelhorTempoResponse = {
+  id_corrida: 11,
+  tempo_total: 93210,
+  data_hora_fim: "2026-05-01T14:30:00",
+  tipo_labirinto: "4X4",
+};
+
+const mockNovoRecorde: MelhorTempoResponse = {
+  id_corrida: 15,
+  tempo_total: 75000,
+  data_hora_fim: "2026-06-01T10:00:00",
+  tipo_labirinto: "4X4",
+};
+
+// ---------------------------------------------------------------------------
+// CT-CMT-INT-01 — Integração hook + service: estado vazio (CA-17-03)
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-INT-01 — Integração: estado vazio via service (CA-17-03)", () => {
+  beforeEach(() => {
+    mockFetchMelhorTempo.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe 'Nenhum desafio concluído ainda' quando service retorna null", async () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Nenhum desafio concluído ainda"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("chama fetchMelhorTempo com o tipo correto", async () => {
+    render(<CardMelhorTempo tipo="8X8" />);
+
+    await waitFor(() => {
+      expect(mockFetchMelhorTempo).toHaveBeenCalledWith("8X8");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-INT-02 — Integração hook + service: com recorde (CA-17-01, CA-17-04)
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-INT-02 — Integração: exibe recorde via service (CA-17-01, CA-17-04)", () => {
+  beforeEach(() => {
+    mockFetchMelhorTempo.mockResolvedValue(mockRecorde);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe o tempo formatado após resolução do service", async () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("01:33.210")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe o id_corrida formatado após resolução do service", async () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^#\d{4}-\d{2}-\d{2}-011$/)).toBeInTheDocument();
+    });
+  });
+
+  it("exibe a data formatada após resolução do service", async () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/01\/05\/2026/)).toBeInTheDocument();
+    });
+  });
+
+  it("exibe loading antes de resolver e recorde depois", async () => {
+    let resolver!: (value: MelhorTempoResponse) => void;
+    mockFetchMelhorTempo.mockReturnValue(
+      new Promise((res) => { resolver = res; }),
+    );
+
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    // loading: valores "--"
+    expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
+
+    // resolve o service
+    await act(async () => {
+      resolver(mockRecorde);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("01:33.210")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-INT-03 — Integração: refetch atualiza o card (CA-17-02)
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-INT-03 — Integração: refetch atualiza valores do card (CA-17-02)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("atualiza o card quando tipo muda (simula novo recorde via prop)", async () => {
+    mockFetchMelhorTempo.mockResolvedValue(mockRecorde);
+
+    const { rerender } = render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("01:33.210")).toBeInTheDocument();
+    });
+
+    // Simula novo recorde para tipo diferente
+    mockFetchMelhorTempo.mockResolvedValue(mockNovoRecorde);
+
+    await act(async () => {
+      rerender(<CardMelhorTempo tipo="8X8" />);
+    });
+
+    await waitFor(() => {
+      // 75000ms = 01:15.000
+      expect(screen.getByText("01:15.000")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe novo recorde via props controladas após refetch", async () => {
+    const { rerender } = render(
+      <CardMelhorTempo tipo="4X4" melhorTempo={mockRecorde} loading={false} erro={null} />,
+    );
+
+    expect(screen.getByText("01:33.210")).toBeInTheDocument();
+
+    // Simula atualização após refetch (CA-17-02)
+    await act(async () => {
+      rerender(
+        <CardMelhorTempo
+          tipo="4X4"
+          melhorTempo={mockNovoRecorde}
+          loading={false}
+          erro={null}
+        />,
+      );
+    });
+
+    expect(screen.getByText("01:15.000")).toBeInTheDocument();
+  });
+
+  it("exibe loading durante refetch e novo recorde depois (CA-17-02)", async () => {
+    const { rerender } = render(
+      <CardMelhorTempo tipo="4X4" melhorTempo={mockRecorde} loading={false} erro={null} />,
+    );
+
+    expect(screen.getByText("01:33.210")).toBeInTheDocument();
+
+    // Simula loading durante refetch
+    await act(async () => {
+      rerender(
+        <CardMelhorTempo tipo="4X4" melhorTempo={null} loading={true} erro={null} />,
+      );
+    });
+
+    expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
+
+    // Resolve com novo recorde
+    await act(async () => {
+      rerender(
+        <CardMelhorTempo
+          tipo="4X4"
+          melhorTempo={mockNovoRecorde}
+          loading={false}
+          erro={null}
+        />,
+      );
+    });
+
+    expect(screen.getByText("01:15.000")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-INT-04 — Integração: tratamento de erro do service
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-INT-04 — Integração: erro do service exibe mensagem", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe mensagem de erro quando service lança exceção", async () => {
+    mockFetchMelhorTempo.mockRejectedValue(new Error("Falha na requisição"));
+
+    render(<CardMelhorTempo tipo="4X4" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Não foi possível carregar/i)).toBeInTheDocument();
+      expect(screen.getByText(/Falha na requisição/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/frontend/src/__tests__/unit/CardMelhorTempo.test.tsx
+++ b/src/frontend/src/__tests__/unit/CardMelhorTempo.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CardMelhorTempo } from "../../components/CardMelhorTempo";
+import type { MelhorTempoResponse } from "../../types/corrida";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/useMelhorTempo", () => ({
+  useMelhorTempo: vi.fn(),
+}));
+
+import { useMelhorTempo } from "../../hooks/useMelhorTempo";
+const mockUseMelhorTempo = vi.mocked(useMelhorTempo);
+
+// ---------------------------------------------------------------------------
+// Dados de teste
+// ---------------------------------------------------------------------------
+
+const mockMelhorTempo: MelhorTempoResponse = {
+  id_corrida: 11,
+  tempo_total: 93210,
+  data_hora_fim: "2026-05-01T14:30:00",
+  tipo_labirinto: "4X4",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function configurarHookAutonomo(
+  melhorTempo: MelhorTempoResponse | null,
+  loading = false,
+  erro: string | null = null,
+) {
+  mockUseMelhorTempo.mockReturnValue({
+    melhorTempo,
+    loading,
+    erro,
+    refetch: vi.fn(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CT-CMT-01 — Estado de carregamento
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-01 — Estado de carregamento", () => {
+  beforeEach(() => {
+    configurarHookAutonomo(null, true);
+  });
+
+  it("exibe '--' nos três cards enquanto carrega (modo autônomo)", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    const valores = screen.getAllByText("--");
+    expect(valores.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("exibe o título 'Melhor Resultado'", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.getByText("Melhor Resultado")).toBeInTheDocument();
+  });
+
+  it("exibe '--' nos três cards enquanto carrega (modo controlado)", () => {
+    render(<CardMelhorTempo tipo="4X4" melhorTempo={null} loading={true} erro={null} />);
+    const valores = screen.getAllByText("--");
+    expect(valores.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-02 — Estado vazio (CA-17-03)
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-02 — Estado vazio: nenhum desafio concluído (CA-17-03)", () => {
+  beforeEach(() => {
+    configurarHookAutonomo(null, false);
+  });
+
+  it("exibe 'Nenhum desafio concluído ainda' no card Sessão", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(
+      screen.getByText("Nenhum desafio concluído ainda"),
+    ).toBeInTheDocument();
+  });
+
+  it("exibe '--' nos cards de Tempo Total e Conquistado em", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    const valores = screen.getAllByText("--");
+    expect(valores.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("exibe o título 'Melhor Resultado'", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.getByText("Melhor Resultado")).toBeInTheDocument();
+  });
+
+  it("NÃO exibe o badge de recorde registrado", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(
+      screen.queryByText(/Recorde registrado/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("exibe estado vazio via props controladas (CA-17-03)", () => {
+    render(
+      <CardMelhorTempo tipo="4X4" melhorTempo={null} loading={false} erro={null} />,
+    );
+    expect(
+      screen.getByText("Nenhum desafio concluído ainda"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-03 — Estado com recorde (CA-17-01, CA-17-04)
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-03 — Estado com recorde: exibe dados da corrida (CA-17-01, CA-17-04)", () => {
+  beforeEach(() => {
+    configurarHookAutonomo(mockMelhorTempo, false);
+  });
+
+  it("exibe o id_corrida formatado (CA-17-04)", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    // Formato #AAAA-MM-DD-NNN
+    expect(screen.getByText(/^#\d{4}-\d{2}-\d{2}-011$/)).toBeInTheDocument();
+  });
+
+  it("exibe o tempo_total formatado via formatarTempo (CA-17-04)", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    // 93210ms = 01:33.210
+    expect(screen.getByText("01:33.210")).toBeInTheDocument();
+  });
+
+  it("exibe a data_hora_fim formatada (CA-17-04)", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    // 2026-05-01T14:30:00 → "01/05/2026, 14:30"
+    expect(screen.getByText(/01\/05\/2026/)).toBeInTheDocument();
+  });
+
+  it("exibe o badge '🏆 Recorde registrado'", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.getByText(/Recorde registrado/i)).toBeInTheDocument();
+  });
+
+  it("exibe os labels dos três cards", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.getByText("Sessão")).toBeInTheDocument();
+    expect(screen.getByText("Tempo Total")).toBeInTheDocument();
+    expect(screen.getByText("Conquistado em")).toBeInTheDocument();
+  });
+
+  it("exibe dados via props controladas", () => {
+    render(
+      <CardMelhorTempo
+        tipo="4X4"
+        melhorTempo={mockMelhorTempo}
+        loading={false}
+        erro={null}
+      />,
+    );
+    expect(screen.getByText("01:33.210")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CT-CMT-04 — Estado de erro
+// ---------------------------------------------------------------------------
+
+describe("CT-CMT-04 — Estado de erro", () => {
+  beforeEach(() => {
+    configurarHookAutonomo(null, false, "Erro de conexão");
+  });
+
+  it("exibe mensagem de erro", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.getByText(/Não foi possível carregar/i)).toBeInTheDocument();
+    expect(screen.getByText(/Erro de conexão/i)).toBeInTheDocument();
+  });
+
+  it("NÃO exibe o título 'Melhor Resultado' em estado de erro", () => {
+    render(<CardMelhorTempo tipo="4X4" />);
+    expect(screen.queryByText("Melhor Resultado")).not.toBeInTheDocument();
+  });
+
+  it("exibe erro via props controladas", () => {
+    render(
+      <CardMelhorTempo
+        tipo="4X4"
+        melhorTempo={null}
+        loading={false}
+        erro="Erro de conexão"
+      />,
+    );
+    expect(screen.getByText(/Erro de conexão/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/CardMelhorTempo.tsx
+++ b/src/frontend/src/components/CardMelhorTempo.tsx
@@ -1,46 +1,40 @@
 /**
  * Componente de destaque visual para o melhor tempo registrado em um labirinto.
  *
- * Reutiliza o padrão de `CardIndicador` de `DashboardIndicadores.tsx`.
- * Chama `useMelhorTempo` internamente — basta passar o `tipo` como prop.
+ * Pode receber os dados via props (modo controlado — usado pela SessionsPage
+ * para coordenar refetch reativo) ou chamar useMelhorTempo internamente
+ * (modo autônomo — uso standalone simples).
  *
- * Uso:
+ * Uso autônomo:
  * ```tsx
- * <CardMelhorTempo tipo="classico" />
+ * <CardMelhorTempo tipo="4X4" />
+ * ```
+ *
+ * Uso controlado (SessionsPage):
+ * ```tsx
+ * <CardMelhorTempo tipo="4X4" melhorTempo={melhorTempo} loading={loading} erro={erro} />
  * ```
  */
 
 import React from "react";
 
-import type { TipoLabirinto } from "../types/corrida";
+import type { MelhorTempoResponse, TipoLabirinto } from "../types/corrida";
 import { useMelhorTempo } from "../hooks/useMelhorTempo";
 
 // ---------------------------------------------------------------------------
-// Helpers (espelham os de DashboardIndicadores)
+// Helpers
 // ---------------------------------------------------------------------------
 
 const formatarTempo = (ms?: number | null): string => {
   if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
     return "00:00.000";
   }
-
   const minutos = Math.floor(ms / 60000);
   const segundos = Math.floor((ms % 60000) / 1000);
   const milissegundos = Math.floor(ms % 1000);
-
-  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(
-    2,
-    "0",
-  )}.${String(milissegundos).padStart(3, "0")}`;
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(2, "0")}.${String(milissegundos).padStart(3, "0")}`;
 };
 
-/**
- * Formata um id_corrida numérico como "#2026-05-01-011".
- *
- * A lógica usa o id como sufixo zero-padded de 3 dígitos combinado com a
- * data atual; em produção, o backend pode enviar o id já formatado — ajuste
- * conforme necessário.
- */
 const formatarIdCorrida = (id: number): string => {
   const hoje = new Date();
   const ano = hoje.getFullYear();
@@ -51,7 +45,6 @@ const formatarIdCorrida = (id: number): string => {
 
 const formatarData = (dataIso: string | null): string => {
   if (!dataIso) return "--";
-
   try {
     return new Intl.DateTimeFormat("pt-BR", {
       day: "2-digit",
@@ -66,8 +59,7 @@ const formatarData = (dataIso: string | null): string => {
 };
 
 // ---------------------------------------------------------------------------
-// CardIndicador — cópia local para não criar dependência circular
-// (igual ao de DashboardIndicadores.tsx)
+// CardIndicador
 // ---------------------------------------------------------------------------
 
 type CardIndicadorProps = {
@@ -110,10 +102,34 @@ const CardIndicador: React.FC<CardIndicadorProps> = ({
 export type CardMelhorTempoProps = {
   /** Tipo do labirinto para buscar o melhor tempo. */
   tipo: TipoLabirinto;
+  /**
+   * Dados do melhor tempo (modo controlado).
+   * Se não fornecido, o componente chama useMelhorTempo internamente.
+   */
+  melhorTempo?: MelhorTempoResponse | null;
+  /** Estado de loading (modo controlado). */
+  loading?: boolean;
+  /** Mensagem de erro (modo controlado). */
+  erro?: string | null;
 };
 
-export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
-  const { melhorTempo, loading, erro } = useMelhorTempo(tipo);
+export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({
+  tipo,
+  melhorTempo: melhorTempoProp,
+  loading: loadingProp,
+  erro: erroProp,
+}) => {
+  // Modo autônomo: chama o hook internamente quando não recebe props externas
+  const autonomo = useMelhorTempo(
+    // Só busca se estiver em modo autônomo (props não fornecidas)
+    melhorTempoProp === undefined && loadingProp === undefined ? tipo : "__skip__",
+  );
+
+  const melhorTempo =
+    melhorTempoProp !== undefined ? melhorTempoProp : autonomo.melhorTempo;
+  const loading =
+    loadingProp !== undefined ? loadingProp : autonomo.loading;
+  const erro = erroProp !== undefined ? erroProp : autonomo.erro;
 
   // ── Estado: carregando
   if (loading) {
@@ -130,16 +146,10 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
             Menor tempo com desafio cumprido para este labirinto.
           </p>
         </header>
-
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {(["Sessão", "Tempo Total", "Conquistado em"] as const).map(
             (titulo) => (
-              <CardIndicador
-                key={titulo}
-                titulo={titulo}
-                valor="--"
-                estado="vazio"
-              />
+              <CardIndicador key={titulo} titulo={titulo} valor="--" estado="vazio" />
             ),
           )}
         </div>
@@ -158,7 +168,7 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
     );
   }
 
-  // ── Estado: vazio (nenhuma corrida concluída com sucesso)
+  // ── Estado: vazio
   if (!melhorTempo) {
     return (
       <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
@@ -173,7 +183,6 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
             Menor tempo com desafio cumprido para este labirinto.
           </p>
         </header>
-
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <CardIndicador
             titulo="Sessão"
@@ -181,11 +190,7 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
             estado="vazio"
           />
           <CardIndicador titulo="Tempo Total" valor="--" estado="vazio" />
-          <CardIndicador
-            titulo="Conquistado em"
-            valor="--"
-            estado="vazio"
-          />
+          <CardIndicador titulo="Conquistado em" valor="--" estado="vazio" />
         </div>
       </div>
     );
@@ -206,12 +211,10 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
             Menor tempo com desafio cumprido para este labirinto.
           </p>
         </div>
-
         <span className="self-start rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700">
           🏆 Recorde registrado
         </span>
       </header>
-
       <main className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <CardIndicador
           titulo="Sessão"
@@ -219,14 +222,12 @@ export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
           descricao="ID da corrida recordista"
           estado="sucesso"
         />
-
         <CardIndicador
           titulo="Tempo Total"
           valor={formatarTempo(melhorTempo.tempo_total)}
           descricao="Menor tempo com desafio cumprido"
           estado="sucesso"
         />
-
         <CardIndicador
           titulo="Conquistado em"
           valor={formatarData(melhorTempo.data_hora_fim)}

--- a/src/frontend/src/components/CardMelhorTempo.tsx
+++ b/src/frontend/src/components/CardMelhorTempo.tsx
@@ -1,0 +1,239 @@
+/**
+ * Componente de destaque visual para o melhor tempo registrado em um labirinto.
+ *
+ * Reutiliza o padrão de `CardIndicador` de `DashboardIndicadores.tsx`.
+ * Chama `useMelhorTempo` internamente — basta passar o `tipo` como prop.
+ *
+ * Uso:
+ * ```tsx
+ * <CardMelhorTempo tipo="classico" />
+ * ```
+ */
+
+import React from "react";
+
+import type { TipoLabirinto } from "../types/corrida";
+import { useMelhorTempo } from "../hooks/useMelhorTempo";
+
+// ---------------------------------------------------------------------------
+// Helpers (espelham os de DashboardIndicadores)
+// ---------------------------------------------------------------------------
+
+const formatarTempo = (ms?: number | null): string => {
+  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
+    return "00:00.000";
+  }
+
+  const minutos = Math.floor(ms / 60000);
+  const segundos = Math.floor((ms % 60000) / 1000);
+  const milissegundos = Math.floor(ms % 1000);
+
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(
+    2,
+    "0",
+  )}.${String(milissegundos).padStart(3, "0")}`;
+};
+
+/**
+ * Formata um id_corrida numérico como "#2026-05-01-011".
+ *
+ * A lógica usa o id como sufixo zero-padded de 3 dígitos combinado com a
+ * data atual; em produção, o backend pode enviar o id já formatado — ajuste
+ * conforme necessário.
+ */
+const formatarIdCorrida = (id: number): string => {
+  const hoje = new Date();
+  const ano = hoje.getFullYear();
+  const mes = String(hoje.getMonth() + 1).padStart(2, "0");
+  const dia = String(hoje.getDate()).padStart(2, "0");
+  return `#${ano}-${mes}-${dia}-${String(id).padStart(3, "0")}`;
+};
+
+const formatarData = (dataIso: string | null): string => {
+  if (!dataIso) return "--";
+
+  try {
+    return new Intl.DateTimeFormat("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(dataIso));
+  } catch {
+    return dataIso;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// CardIndicador — cópia local para não criar dependência circular
+// (igual ao de DashboardIndicadores.tsx)
+// ---------------------------------------------------------------------------
+
+type CardIndicadorProps = {
+  titulo: string;
+  valor: string;
+  descricao?: string;
+  estado?: "normal" | "critico" | "sucesso" | "vazio";
+};
+
+const CardIndicador: React.FC<CardIndicadorProps> = ({
+  titulo,
+  valor,
+  descricao,
+  estado = "normal",
+}) => {
+  const estilos = {
+    normal: "border-neutral-200 bg-white text-neutral-900",
+    critico: "border-red-300 bg-red-50 text-red-950",
+    sucesso: "border-green-300 bg-green-50 text-green-950",
+    vazio: "border-neutral-200 bg-neutral-50 text-neutral-400",
+  }[estado];
+
+  return (
+    <section className={`rounded-xl border p-5 transition-colors ${estilos}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+        {titulo}
+      </p>
+      <p className="mt-3 text-3xl font-semibold tracking-tight">{valor}</p>
+      {descricao && (
+        <p className="mt-2 text-xs text-current opacity-75">{descricao}</p>
+      )}
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// CardMelhorTempo
+// ---------------------------------------------------------------------------
+
+export type CardMelhorTempoProps = {
+  /** Tipo do labirinto para buscar o melhor tempo. */
+  tipo: TipoLabirinto;
+};
+
+export const CardMelhorTempo: React.FC<CardMelhorTempoProps> = ({ tipo }) => {
+  const { melhorTempo, loading, erro } = useMelhorTempo(tipo);
+
+  // ── Estado: carregando
+  if (loading) {
+    return (
+      <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+        <header className="mb-6 border-b border-neutral-100 pb-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Recorde
+          </p>
+          <h2 className="text-2xl font-semibold text-neutral-950">
+            Melhor Resultado
+          </h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            Menor tempo com desafio cumprido para este labirinto.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {(["Sessão", "Tempo Total", "Conquistado em"] as const).map(
+            (titulo) => (
+              <CardIndicador
+                key={titulo}
+                titulo={titulo}
+                valor="--"
+                estado="vazio"
+              />
+            ),
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Estado: erro
+  if (erro) {
+    return (
+      <div className="w-full rounded-2xl border border-red-200 bg-red-50 p-6 shadow-sm">
+        <p className="text-sm font-medium text-red-700">
+          ⚠️ Não foi possível carregar o melhor tempo: {erro}
+        </p>
+      </div>
+    );
+  }
+
+  // ── Estado: vazio (nenhuma corrida concluída com sucesso)
+  if (!melhorTempo) {
+    return (
+      <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+        <header className="mb-6 border-b border-neutral-100 pb-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Recorde
+          </p>
+          <h2 className="text-2xl font-semibold text-neutral-950">
+            Melhor Resultado
+          </h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            Menor tempo com desafio cumprido para este labirinto.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <CardIndicador
+            titulo="Sessão"
+            valor="Nenhum desafio concluído ainda"
+            estado="vazio"
+          />
+          <CardIndicador titulo="Tempo Total" valor="--" estado="vazio" />
+          <CardIndicador
+            titulo="Conquistado em"
+            valor="--"
+            estado="vazio"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Estado: com resultado
+  return (
+    <div className="w-full rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+      <header className="mb-6 flex flex-col gap-3 border-b border-neutral-100 pb-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Recorde
+          </p>
+          <h2 className="text-2xl font-semibold text-neutral-950">
+            Melhor Resultado
+          </h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            Menor tempo com desafio cumprido para este labirinto.
+          </p>
+        </div>
+
+        <span className="self-start rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700">
+          🏆 Recorde registrado
+        </span>
+      </header>
+
+      <main className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <CardIndicador
+          titulo="Sessão"
+          valor={formatarIdCorrida(melhorTempo.id_corrida)}
+          descricao="ID da corrida recordista"
+          estado="sucesso"
+        />
+
+        <CardIndicador
+          titulo="Tempo Total"
+          valor={formatarTempo(melhorTempo.tempo_total)}
+          descricao="Menor tempo com desafio cumprido"
+          estado="sucesso"
+        />
+
+        <CardIndicador
+          titulo="Conquistado em"
+          valor={formatarData(melhorTempo.data_hora_fim)}
+          descricao="Data e hora da conquista"
+          estado="sucesso"
+        />
+      </main>
+    </div>
+  );
+};

--- a/src/frontend/src/hooks/useMelhorTempo.ts
+++ b/src/frontend/src/hooks/useMelhorTempo.ts
@@ -1,0 +1,78 @@
+/**
+ * Hook React para buscar e manter o melhor tempo de um labirinto.
+ *
+ * Uso:
+ * ```tsx
+ * const { melhorTempo, loading, erro, refetch } = useMelhorTempo("classico");
+ * ```
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { MelhorTempoResponse } from "../types/corrida";
+import { fetchMelhorTempo } from "../services/corrida";
+
+export interface UseMelhorTempoReturn {
+  /** Dados do melhor tempo, ou `null` se nenhum desafio foi concluído. */
+  melhorTempo: MelhorTempoResponse | null;
+  /** `true` enquanto a requisição está em andamento. */
+  loading: boolean;
+  /** Mensagem de erro, ou `null` se não houver erro. */
+  erro: string | null;
+  /** Reexecuta a busca manualmente (ex: após nova corrida encerrada). */
+  refetch: () => void;
+}
+
+/**
+ * Busca o melhor tempo para o `tipo` de labirinto informado.
+ * Reexecuta automaticamente quando `tipo` muda.
+ */
+export function useMelhorTempo(tipo: string): UseMelhorTempoReturn {
+  const [melhorTempo, setMelhorTempo] = useState<MelhorTempoResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  // Contador interno usado para disparar re-fetches via refetch()
+  const [contador, setContador] = useState(0);
+
+  const refetch = useCallback(() => {
+    setContador((c) => c + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelado = false;
+
+    async function buscar() {
+      setLoading(true);
+      setErro(null);
+
+      try {
+        const resultado = await fetchMelhorTempo(tipo);
+
+        if (!cancelado) {
+          setMelhorTempo(resultado);
+        }
+      } catch (e) {
+        if (!cancelado) {
+          setErro(
+            e instanceof Error ? e.message : "Erro ao buscar melhor tempo.",
+          );
+        }
+      } finally {
+        if (!cancelado) {
+          setLoading(false);
+        }
+      }
+    }
+
+    buscar();
+
+    return () => {
+      cancelado = true;
+    };
+    // `contador` como dependência garante que refetch() re-execute o efeito
+  }, [tipo, contador]);
+
+  return { melhorTempo, loading, erro, refetch };
+}

--- a/src/frontend/src/hooks/useTelemetria.ts
+++ b/src/frontend/src/hooks/useTelemetria.ts
@@ -82,9 +82,25 @@ export interface UseTelemetriaReturn {
   filaMovimentacoes: MovimentacaoTelemetria[];
   /** Limpa a fila apos processar */
   limparFilaMovimentacoes: () => void;
+  /**
+   * Contador incrementado a cada SESSAO_ENCERRADA com sucesso=true.
+   * Componentes podem usar como dependência para disparar refetch.
+   * (CA-17-02)
+   */
+  contadorNovoRecorde: number;
 }
 
-export function useTelemetria(): UseTelemetriaReturn {
+type UseTelemetriaOptions = {
+  /**
+   * Callback chamado quando SESSAO_ENCERRADA chega com sucesso=true.
+   * Use para disparar refetch do melhor tempo e exibir toast de novo recorde.
+   */
+  onSessaoEncerradaComSucesso?: () => void;
+};
+
+export function useTelemetria(
+  options?: UseTelemetriaOptions,
+): UseTelemetriaReturn {
   const [indicadores, setIndicadores] = useState<IndicadoresDesempenho>(() => {
     const indicadoresSalvos = localStorage.getItem("indicadores");
     return indicadoresSalvos ? JSON.parse(indicadoresSalvos) : ESTADO_INICIAL;
@@ -109,6 +125,13 @@ export function useTelemetria(): UseTelemetriaReturn {
   const [filaMovimentacoes, setFilaMovimentacoes] = useState<
     MovimentacaoTelemetria[]
   >([]);
+  const [contadorNovoRecorde, setContadorNovoRecorde] = useState(0);
+
+  // Ref para manter o callback sempre atualizado sem recriar o WebSocket
+  const onSessaoEncerradaRef = useRef(options?.onSessaoEncerradaComSucesso);
+  useEffect(() => {
+    onSessaoEncerradaRef.current = options?.onSessaoEncerradaComSucesso;
+  }, [options?.onSessaoEncerradaComSucesso]);
 
   const limparFilaMovimentacoes = useCallback(() => {
     setFilaMovimentacoes([]);
@@ -117,14 +140,12 @@ export function useTelemetria(): UseTelemetriaReturn {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Decodifica o inteiro de paredes (w) em um binário para identificar as paredes presentes na célula.
   const decodificarParedes = useCallback((w: number): ParedesCelula => {
-    // o "&" é o operador bit-a-bit AND. Ele “pega” apenas o bit indicado.
     return {
-      norte: (w & 1) === 1, //Se (w & 1) === 1, o bit 0 esta ligado → parede ao norte.
-      sul: (w & 2) === 2, //Se (w & 2) === 2, o bit 1 esta ligado → parede ao sul.
-      leste: (w & 4) === 4, //Se (w & 4) === 4, o bit 2 esta ligado → parede ao leste.
-      oeste: (w & 8) === 8, //Se (w & 8) === 8, o bit 3 esta ligado → parede ao oeste.
+      norte: (w & 1) === 1,
+      sul: (w & 2) === 2,
+      leste: (w & 4) === 4,
+      oeste: (w & 8) === 8,
     };
   }, []);
 
@@ -155,14 +176,12 @@ export function useTelemetria(): UseTelemetriaReturn {
     [],
   );
 
-  //Persistir estado no localStorage para manter dados entre recarregamentos
   useEffect(() => {
     localStorage.setItem("indicadores", JSON.stringify(indicadores));
     localStorage.setItem("configSessao", JSON.stringify(configSessao));
   }, [indicadores, configSessao]);
 
   const realizarConexao = useCallback(function conectar() {
-    // Evitar conexões duplicadas
     if (
       wsRef.current &&
       (wsRef.current.readyState === WebSocket.OPEN ||
@@ -183,10 +202,10 @@ export function useTelemetria(): UseTelemetriaReturn {
         const parsed = JSON.parse(event.data);
         const payload = parsed?.data ?? parsed;
         console.log("[useTelemetria] Mensagem recebida INICIAL:", parsed);
-        // Tratar erros enviados pelo backend
+
         if (parsed.type === "ERROR") {
           toast.error(parsed.message || "Erro na telemetria", {
-            id: "telemetria-error", // Evita toasts duplicados
+            id: "telemetria-error",
           });
           return;
         }
@@ -204,6 +223,13 @@ export function useTelemetria(): UseTelemetriaReturn {
             "[useTelemetria] Sessão anterior encerrada:",
             parsed.data,
           );
+
+          // CA-17-02: se a sessão foi encerrada com sucesso, pode haver novo recorde
+          if (parsed.data?.sucesso === true) {
+            setContadorNovoRecorde((c) => c + 1);
+            onSessaoEncerradaRef.current?.();
+          }
+
           setIndicadores(ESTADO_INICIAL);
           setConfigSessao(CONFIG_SESSAO_INICIAL);
           setStatusConexao("waiting");
@@ -216,7 +242,6 @@ export function useTelemetria(): UseTelemetriaReturn {
           parsed?.type === "MOVIMENTACAO_PAREDES" ||
           isMovimentacaoPayload(payload)
         ) {
-          // console.log("[useTelemetria] Movimentação recebida:", payload);
           if (isMovimentacaoPayload(payload)) {
             const mov = {
               ...payload,
@@ -248,10 +273,13 @@ export function useTelemetria(): UseTelemetriaReturn {
           setIndicadores(indicadoresData as IndicadoresDesempenho);
           setStatusConexao("online");
           setMensagemStatusConexao(null);
-          toast.error(`Alerta Crítico: Temperatura em ${temp_c}ºC! Corrida abortada.`, {
-            id: "alerta-temperatura",
-            duration: 5000,
-          });
+          toast.error(
+            `Alerta Crítico: Temperatura em ${temp_c}ºC! Corrida abortada.`,
+            {
+              id: "alerta-temperatura",
+              duration: 5000,
+            },
+          );
         }
       } catch (e) {
         console.error("[useTelemetria] Erro ao processar mensagem:", e);
@@ -265,8 +293,6 @@ export function useTelemetria(): UseTelemetriaReturn {
     ws.onclose = () => {
       setConectado(false);
       wsRef.current = null;
-
-      // Reconexão automática
       reconnectTimerRef.current = setTimeout(conectar, RECONNECT_INTERVAL_MS);
     };
 
@@ -277,7 +303,6 @@ export function useTelemetria(): UseTelemetriaReturn {
     realizarConexao();
 
     return () => {
-      // Cleanup ao desmontar
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
       }
@@ -308,5 +333,6 @@ export function useTelemetria(): UseTelemetriaReturn {
     ultimaMovimentacao,
     filaMovimentacoes,
     limparFilaMovimentacoes,
+    contadorNovoRecorde,
   };
 }

--- a/src/frontend/src/pages/SessionsPage.tsx
+++ b/src/frontend/src/pages/SessionsPage.tsx
@@ -154,7 +154,7 @@ export function SessionsPage({
     const atual = melhorTempo.tempo_total;
 
     if (anterior !== null && atual < anterior) {
-      toast.success("🏆 Novo recorde!", { id: "novo-recorde", duration: 4000 });
+      toast.success("Novo recorde!", { id: "novo-recorde", duration: 4000 });
     }
 
     melhorTempoAnteriorRef.current = atual;

--- a/src/frontend/src/pages/SessionsPage.tsx
+++ b/src/frontend/src/pages/SessionsPage.tsx
@@ -1,0 +1,293 @@
+/**
+ * Página de histórico de sessões (corridas).
+ *
+ * Exibe o CardMelhorTempo como destaque visual e uma tabela com todas as
+ * corridas registradas, com filtro por tipo de labirinto.
+ */
+
+import { useEffect, useState } from "react";
+
+import { CardMelhorTempo } from "../components/CardMelhorTempo";
+import { MonitoringLayout } from "../components/MonitoringLayout";
+import { listarCorridasResumo } from "../services/corrida";
+import type {
+  CorridaResumoResponse,
+  TipoLabirinto,
+  TipoLabirintoFiltro,
+} from "../types/corrida";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatarTempo = (ms?: number | null): string => {
+  if (ms === null || ms === undefined || Number.isNaN(ms) || ms < 0) {
+    return "--";
+  }
+  const minutos = Math.floor(ms / 60000);
+  const segundos = Math.floor((ms % 60000) / 1000);
+  const milissegundos = Math.floor(ms % 1000);
+  return `${String(minutos).padStart(2, "0")}:${String(segundos).padStart(2, "0")}.${String(milissegundos).padStart(3, "0")}`;
+};
+
+const formatarData = (dataIso: string | null): string => {
+  if (!dataIso) return "--";
+  try {
+    return new Intl.DateTimeFormat("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(dataIso));
+  } catch {
+    return dataIso;
+  }
+};
+
+const formatarIdCorrida = (id: number): string => {
+  const hoje = new Date();
+  const ano = hoje.getFullYear();
+  const mes = String(hoje.getMonth() + 1).padStart(2, "0");
+  const dia = String(hoje.getDate()).padStart(2, "0");
+  return `#${ano}-${mes}-${dia}-${String(id).padStart(3, "0")}`;
+};
+
+// ---------------------------------------------------------------------------
+// Badge de status
+// ---------------------------------------------------------------------------
+
+type StatusCorrida = CorridaResumoResponse["status_corrida"];
+
+const badgeStatus: Record<StatusCorrida, { label: string; classes: string }> =
+  {
+    CONCLUIDA: {
+      label: "Concluída",
+      classes: "bg-green-100 text-green-700",
+    },
+    ABORTADA: {
+      label: "Abortada",
+      classes: "bg-red-100 text-red-700",
+    },
+    EM_ANDAMENTO: {
+      label: "Em andamento",
+      classes: "bg-amber-100 text-amber-700",
+    },
+  };
+
+const BadgeStatus: React.FC<{ status: StatusCorrida }> = ({ status }) => {
+  const { label, classes } = badgeStatus[status] ?? {
+    label: status,
+    classes: "bg-neutral-100 text-neutral-600",
+  };
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${classes}`}>
+      {label}
+    </span>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Filtro de tipo
+// ---------------------------------------------------------------------------
+
+const TIPOS: { value: TipoLabirintoFiltro; label: string }[] = [
+  { value: "TODOS", label: "Todos" },
+  { value: "4X4", label: "4×4" },
+  { value: "8X8", label: "8×8" },
+  { value: "16X16", label: "16×16" },
+];
+
+// ---------------------------------------------------------------------------
+// SessionsPage
+// ---------------------------------------------------------------------------
+
+type SessionsPageProps = {
+  activeView: "telemetria" | "labirinto" | "corridas";
+  onNavigateTelemetria: () => void;
+  onNavigateLabirinto: () => void;
+  onNavigateCorridas: () => void;
+};
+
+export function SessionsPage({
+  activeView,
+  onNavigateTelemetria,
+  onNavigateLabirinto,
+  onNavigateCorridas,
+}: SessionsPageProps) {
+  const [corridas, setCorridas] = useState<CorridaResumoResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const [tipoSelecionado, setTipoSelecionado] =
+    useState<TipoLabirintoFiltro>("TODOS");
+
+  useEffect(() => {
+    let cancelado = false;
+
+    async function buscar() {
+      setLoading(true);
+      setErro(null);
+      try {
+        const tipo =
+          tipoSelecionado === "TODOS" ? undefined : tipoSelecionado;
+        const resultado = await listarCorridasResumo(tipo);
+        if (!cancelado) setCorridas(resultado);
+      } catch (e) {
+        if (!cancelado)
+          setErro(
+            e instanceof Error ? e.message : "Erro ao carregar corridas.",
+          );
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
+    }
+
+    buscar();
+    return () => {
+      cancelado = true;
+    };
+  }, [tipoSelecionado]);
+
+  // Tipo para o CardMelhorTempo — usa o primeiro tipo concreto selecionado,
+  // ou "4X4" como padrão quando filtro é "TODOS"
+  const tipoParaRecorde: TipoLabirinto =
+    tipoSelecionado === "TODOS" ? "4X4" : tipoSelecionado;
+
+  return (
+    <MonitoringLayout
+      activeView={activeView}
+      onNavigateTelemetria={onNavigateTelemetria}
+      onNavigateLabirinto={onNavigateLabirinto}
+      onNavigateCorridas={onNavigateCorridas}
+      eyebrow="Corridas"
+      title="Histórico de Sessões"
+      description="Consulte todas as corridas registradas e veja o melhor resultado por tipo de labirinto."
+      statusConexao="waiting"
+      mensagemStatusConexao={null}
+    >
+      {/* Destaque: melhor tempo (CA-17-01) */}
+      <div className="mb-8">
+        <CardMelhorTempo tipo={tipoParaRecorde} />
+      </div>
+
+      {/* Filtro por tipo */}
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+          Filtrar por tipo:
+        </span>
+        <div className="flex gap-1">
+          {TIPOS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTipoSelecionado(value)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+                tipoSelecionado === value
+                  ? "bg-zinc-950 text-white"
+                  : "bg-white text-zinc-600 border border-zinc-200 hover:bg-zinc-50"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tabela de corridas */}
+      <div className="w-full rounded-2xl border border-neutral-200 bg-white shadow-sm overflow-hidden">
+        <div className="border-b border-neutral-100 px-6 py-4">
+          <h2 className="text-lg font-semibold text-zinc-950">Corridas</h2>
+          <p className="text-sm text-zinc-500">
+            {loading
+              ? "Carregando..."
+              : `${corridas.length} corrida${corridas.length !== 1 ? "s" : ""} encontrada${corridas.length !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+
+        {erro && (
+          <div className="mx-6 my-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700">
+            ⚠️ {erro}
+          </div>
+        )}
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-100 bg-neutral-50">
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Data / Hora
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Dimensão
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Duração
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Vel. Média
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Resultado
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                // Skeleton rows
+                Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i} className="border-b border-neutral-100">
+                    {Array.from({ length: 6 }).map((_, j) => (
+                      <td key={j} className="px-6 py-4">
+                        <div className="h-4 w-24 animate-pulse rounded bg-neutral-100" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : corridas.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-6 py-12 text-center text-sm text-zinc-400"
+                  >
+                    Nenhuma corrida encontrada para este filtro.
+                  </td>
+                </tr>
+              ) : (
+                corridas.map((corrida) => (
+                  <tr
+                    key={corrida.id_corrida}
+                    className="border-b border-neutral-100 transition hover:bg-neutral-50"
+                  >
+                    <td className="px-6 py-4 font-mono text-xs text-zinc-500">
+                      {formatarIdCorrida(corrida.id_corrida)}
+                    </td>
+                    <td className="px-6 py-4 text-zinc-700">
+                      {formatarData(corrida.data_hora_inicio)}
+                    </td>
+                    <td className="px-6 py-4 text-zinc-700">
+                      {corrida.tipo_labirinto ?? "--"}
+                    </td>
+                    <td className="px-6 py-4 font-mono text-zinc-700">
+                      {formatarTempo(corrida.tempo_total)}
+                    </td>
+                    <td className="px-6 py-4 text-zinc-700">
+                      {corrida.velocidade_media != null
+                        ? `${corrida.velocidade_media.toFixed(2)} cm/s`
+                        : "--"}
+                    </td>
+                    <td className="px-6 py-4">
+                      <BadgeStatus status={corrida.status_corrida} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </MonitoringLayout>
+  );
+}

--- a/src/frontend/src/pages/SessionsPage.tsx
+++ b/src/frontend/src/pages/SessionsPage.tsx
@@ -5,10 +5,13 @@
  * corridas registradas, com filtro por tipo de labirinto.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 
 import { CardMelhorTempo } from "../components/CardMelhorTempo";
 import { MonitoringLayout } from "../components/MonitoringLayout";
+import { useMelhorTempo } from "../hooks/useMelhorTempo";
+import { useTelemetria } from "../hooks/useTelemetria";
 import { listarCorridasResumo } from "../services/corrida";
 import type {
   CorridaResumoResponse,
@@ -120,7 +123,44 @@ export function SessionsPage({
   const [erro, setErro] = useState<string | null>(null);
   const [tipoSelecionado, setTipoSelecionado] =
     useState<TipoLabirintoFiltro>("TODOS");
+  const [contadorTabela, setContadorTabela] = useState(0);
 
+  // Tipo para o CardMelhorTempo
+  const tipoParaRecorde: TipoLabirinto =
+    tipoSelecionado === "TODOS" ? "4X4" : tipoSelecionado;
+
+  // Hook do melhor tempo — controlamos o refetch manualmente (CA-17-02)
+  const { melhorTempo, loading: loadingRecorde, erro: erroRecorde, refetch } =
+    useMelhorTempo(tipoParaRecorde);
+
+  // Ref para comparar tempo anterior e exibir toast de novo recorde
+  const melhorTempoAnteriorRef = useRef<number | null>(null);
+
+  // CA-17-02: ao receber SESSAO_ENCERRADA com sucesso=true, refetch + toast
+  const handleSessaoEncerradaComSucesso = useCallback(() => {
+    refetch();
+    setContadorTabela((c) => c + 1);
+  }, [refetch]);
+
+  const telemetria = useTelemetria({
+    onSessaoEncerradaComSucesso: handleSessaoEncerradaComSucesso,
+  });
+
+  // Exibe toast de novo recorde quando o melhorTempo mudar para um valor menor
+  useEffect(() => {
+    if (melhorTempo === null) return;
+
+    const anterior = melhorTempoAnteriorRef.current;
+    const atual = melhorTempo.tempo_total;
+
+    if (anterior !== null && atual < anterior) {
+      toast.success("🏆 Novo recorde!", { id: "novo-recorde", duration: 4000 });
+    }
+
+    melhorTempoAnteriorRef.current = atual;
+  }, [melhorTempo]);
+
+  // Busca a tabela de corridas
   useEffect(() => {
     let cancelado = false;
 
@@ -146,12 +186,7 @@ export function SessionsPage({
     return () => {
       cancelado = true;
     };
-  }, [tipoSelecionado]);
-
-  // Tipo para o CardMelhorTempo — usa o primeiro tipo concreto selecionado,
-  // ou "4X4" como padrão quando filtro é "TODOS"
-  const tipoParaRecorde: TipoLabirinto =
-    tipoSelecionado === "TODOS" ? "4X4" : tipoSelecionado;
+  }, [tipoSelecionado, contadorTabela]);
 
   return (
     <MonitoringLayout
@@ -162,12 +197,17 @@ export function SessionsPage({
       eyebrow="Corridas"
       title="Histórico de Sessões"
       description="Consulte todas as corridas registradas e veja o melhor resultado por tipo de labirinto."
-      statusConexao="waiting"
-      mensagemStatusConexao={null}
+      statusConexao={telemetria.statusConexao}
+      mensagemStatusConexao={telemetria.mensagemStatusConexao}
     >
       {/* Destaque: melhor tempo (CA-17-01) */}
       <div className="mb-8">
-        <CardMelhorTempo tipo={tipoParaRecorde} />
+        <CardMelhorTempo
+          tipo={tipoParaRecorde}
+          melhorTempo={melhorTempo}
+          loading={loadingRecorde}
+          erro={erroRecorde}
+        />
       </div>
 
       {/* Filtro por tipo */}
@@ -236,7 +276,6 @@ export function SessionsPage({
             </thead>
             <tbody>
               {loading ? (
-                // Skeleton rows
                 Array.from({ length: 5 }).map((_, i) => (
                   <tr key={i} className="border-b border-neutral-100">
                     {Array.from({ length: 6 }).map((_, j) => (

--- a/src/frontend/src/services/corrida.ts
+++ b/src/frontend/src/services/corrida.ts
@@ -41,3 +41,23 @@ export async function obterCorrida(
 ): Promise<CorridaDetailResponse> {
   return request<CorridaDetailResponse>(`/api/corridas/${idCorrida}`);
 }
+
+export async function fetchMelhorTempo(
+  tipo: string,
+): Promise<MelhorTempoResponse | null> {
+  const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+  const url = `${API_BASE}/api/corridas/melhor-tempo?tipo=${encodeURIComponent(tipo)}`;
+
+  const response = await fetch(url);
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || `Erro ao acessar /api/corridas/melhor-tempo`);
+  }
+
+  return response.json() as Promise<MelhorTempoResponse>;
+}

--- a/src/frontend/src/types/corrida.ts
+++ b/src/frontend/src/types/corrida.ts
@@ -74,3 +74,11 @@ export interface CorridaResumoResponse {
 export interface CorridaDetailResponse extends CorridaResponse {
   percurso: PercursoResponse[];
 }
+
+/** Resposta do endpoint GET /api/corridas/melhor-tempo?tipo=<tipo> */
+export interface MelhorTempoResponse {
+  id_corrida: number;
+  tempo_total: number;
+  data_hora_fim: string | null;
+  tipo_labirinto: string | null;
+}


### PR DESCRIPTION
<html><head></head><body><h2>Descrição</h2>
<p>Implementa a visualização do melhor resultado registrado para um labirinto (menor tempo de conclusão com desafio cumprido), conforme especificado na US-17.</p>
<blockquote>
<p><strong>Como</strong> avaliador, <strong>quero</strong> ver rapidamente o melhor resultado registrado para um labirinto, <strong>para</strong> ter uma referência imediata do desempenho máximo alcançado e comparar com novas execuções.</p>
</blockquote>
<hr>
<h2>Tasks implementadas</h2>

Task | Descrição
-- | --
#368 | Frontend: Componente CardMelhorTempo
#367 | Frontend: Service fetchMelhorTempo e hook useMelhorTempo
#365 | Frontend: Página SessionsPage com tabela e destaque
#364 | Frontend: Atualização reativa após nova corrida
#363 | Frontend: Testes unitários e de integração


<hr>
<h2>Arquivos alterados</h2>
<p><strong>Frontend</strong></p>
<ul>
<li><code>types/corrida.ts</code> — adicionado <code>MelhorTempoResponse</code></li>
<li><code>services/corrida.ts</code> — adicionado <code>fetchMelhorTempo()</code></li>
<li><code>hooks/useMelhorTempo.ts</code> — criado</li>
<li><code>hooks/useTelemetria.ts</code> — adicionado <code>onSessaoEncerradaComSucesso</code> e <code>contadorNovoRecorde</code></li>
<li><code>components/CardMelhorTempo.tsx</code> — criado</li>
<li><code>pages/SessionsPage.tsx</code> — criado</li>
<li><code>App.tsx</code> — adicionada view <code>corridas</code></li>
<li><code>__tests__/unit/CardMelhorTempo.test.tsx</code> — criado</li>
<li><code>__tests__/integration/CardMelhorTempo.integration.test.tsx</code> — criado</li>
</ul>
<p><strong>Backend</strong></p>
<ul>
<li><code>routers/corridas.py</code> — adicionado <code>GET /api/corridas/melhor-tempo?tipo=&lt;tipo&gt;</code>, posicionado antes de <code>/{id_corrida}</code> para evitar conflito de rota</li>
</ul>
<hr>
<h2>Mudanças técnicas relevantes</h2>
<p><strong>Novo endpoint backend</strong></p>
<p>Retorna a corrida com menor <code>tempo_total</code> onde <code>desafio_cumprido = true</code> para o tipo informado. Retorna <code>404</code> quando não há corridas concluídas com sucesso.</p>
<p><strong>CardMelhorTempo — dois modos de uso</strong></p>
<p>Suporta modo autônomo (chama <code>useMelhorTempo</code> internamente) e modo controlado (recebe dados via props), permitindo que a <code>SessionsPage</code> coordene o <code>refetch</code> sem duplicar requisições.</p>
<p><strong>Atualização reativa (CA-17-02)</strong></p>
<p><code>useTelemetria</code> foi estendido com <code>onSessaoEncerradaComSucesso</code>, disparado ao receber <code>SESSAO_ENCERRADA</code> com <code>sucesso: true</code> via WebSocket. A <code>SessionsPage</code> usa esse callback para chamar <code>refetch()</code>, recarregar a tabela e exibir o toast <code>"Novo recorde!"</code> quando o novo tempo for menor que o anterior.</p>
<hr>
<h2>Screenshots</h2>
<p><strong>CardMelhorTempo — Estado vazio (CA-17-03)</strong></p>
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/ffe98ca8-84da-4399-91b3-49be06927d66" />
<p><strong>SessionsPage — Visão completa (CA-17-01, CA-17-04)</strong></p>
<img width="1300" height="651" alt="image" src="https://github.com/user-attachments/assets/c0a58511-7ac7-4782-aa07-787037ba0fa5" />
<p><strong>Testes — 89/89 passando</strong></p>
<img width="913" height="580" alt="image" src="https://github.com/user-attachments/assets/1839789b-f411-4dcb-86b0-ef64786de7cc" />
<hr>
<h2>Como testar</h2>
<ol>
<li>Suba o ambiente:</li>
</ol>
<pre><code class="language-bash">cd backend &amp;&amp; docker compose up
cd frontend &amp;&amp; nvm use 20 &amp;&amp; npm run dev
</code></pre>
<ol start="2">
<li>Acesse <code>http://localhost:5173</code> e navegue até <strong>Corridas</strong> no menu lateral.</li>
<li>Verifique o estado vazio: o card deve exibir <strong>"Nenhum desafio concluído ainda"</strong>.</li>
<li>Realize uma corrida com sucesso — o card deve atualizar automaticamente e exibir o toast <strong>" Novo recorde!"</strong>.</li>
<li>Teste o filtro por tipo (4×4 / 8×8 / 16×16).</li>
<li>Rode os testes: <code>npx vitest run</code> — esperado: <strong>89 passed (89)</strong>.</li>
</ol>
<hr>
<h2>Relacionado</h2>
<ul>
<li>Closes #363</li>
<li>Closes #364</li>
<li>Closes #365</li>
<li>Closes #367</li>
<li>Closes #368</li>
<li>Relacionado a #360 e #366 (backend — PR separado)</li>
</ul></body></html>