### PR TITLE
fix(telemetria): atualizar tempo exibido com heartbeat

### DIFF
--- a/src/backend/app/services/telemetria.py
+++ b/src/backend/app/services/telemetria.py
@@ -445,6 +445,7 @@ def _processar_pacote_heartbeat(
 ) -> None:
     """Processa um Heartbeat (tipo=4): atualiza bateria e timestamp."""
     estado.bateria_atual = pacote["bateria"]
+    estado.tempo_decorrido_ms = pacote["timestamp_ms"]
     estado.ultimo_timestamp_ms = pacote["timestamp_ms"]
     _atualizar_alerta_bateria_critica(
         estado,

--- a/src/backend/tests/test_integracao_firmware.py
+++ b/src/backend/tests/test_integracao_firmware.py
@@ -457,6 +457,7 @@ class TestBroadcastWebSocket:
             msgs = self._collect_until(ws, "HEARTBEAT")
             hb_msg = next(m for m in msgs if m["type"] == "HEARTBEAT")
             assert hb_msg["data"]["bateria_atual"] == 93
+            assert hb_msg["data"]["tempo_decorrido_ms"] == 1500
 
     def test_tipo5_broadcast_alerta_temperatura(self, client):
         with client.websocket_connect("/api/telemetria/ws") as ws:

--- a/src/backend/tests/test_novos_pacotes.py
+++ b/src/backend/tests/test_novos_pacotes.py
@@ -95,6 +95,11 @@ class TestProcessarHeartbeat:
         e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
         assert e.bateria_atual == 93
 
+    def test_heartbeat_atualiza_tempo_decorrido(self):
+        e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
+        e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
+        assert e.tempo_decorrido_ms == 1500
+
     def test_heartbeat_atualiza_timestamp(self):
         e = atualizar_indicadores(criar_estado_inicial(), PACOTE_INICIAL)
         e = atualizar_indicadores(e, PACOTE_HEARTBEAT)
@@ -171,6 +176,11 @@ class TestHeartbeatRouter:
         client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
         r = client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT)
         assert r.json()["estado"]["bateria_atual"] == 93
+
+    def test_heartbeat_atualiza_tempo_no_estado(self, client: TestClient):
+        client.post("/api/telemetria/pacote", json=PACOTE_INICIAL)
+        r = client.post("/api/telemetria/pacote", json=PACOTE_HEARTBEAT)
+        assert r.json()["estado"]["tempo_decorrido_ms"] == 1500
 
     def test_heartbeat_persiste_alerta_bateria_critica(self, client: TestClient, session: Session):
         idb = client.post("/api/telemetria/pacote", json=PACOTE_INICIAL).json()["estado"]["id_corrida_banco"]


### PR DESCRIPTION
## Resumo
Corrige um bug na tela de monitoramento em que o timestamp/tempo exibido só era atualizado por pacotes de movimentação. Agora, pacotes de `heartbeat` também atualizam o tempo da sessão, mantendo a interface sincronizada mesmo quando o Micromouse está parado.

## O que foi alterado
- atualiza `tempo_decorrido_ms` no processamento de pacotes `heartbeat`
- adiciona testes para garantir que o tempo da sessão avança com `heartbeat`

## Motivação
O frontend usa `tempo_decorrido_ms` para exibir o tempo/timestamp da corrida. Como esse campo não era atualizado em `heartbeat`, a tela ficava com o tempo congelado enquanto o robô permanecia sem movimentação, mesmo com pacotes válidos sendo recebidos.

Closes #450 